### PR TITLE
Use BCP-47 code for language code

### DIFF
--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/common/locale/LocaleManager.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/common/locale/LocaleManager.java
@@ -17,7 +17,7 @@ public class LocaleManager {
 
     private void initLang() {
         Locale defaultLocale = Locale.getDefault();
-        mLang = defaultLocale.getLanguage();
+        mLang = defaultLocale.toLanguageTag();
         mCountry = defaultLocale.getCountry();
     }
 


### PR DESCRIPTION
Use BCP-47 code for language code to get content with correct language.
For example, BCP-47 has zn-CN for simplified Chinese and zh-TW for traditional Chinese.