### PR TITLE
Add auto-translate subtitles

### DIFF
--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/common/converters/regexpandjsonpath/RegExpAndJsonPath.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/common/converters/regexpandjsonpath/RegExpAndJsonPath.java
@@ -1,0 +1,15 @@
+package com.liskovsoft.youtubeapi.common.converters.regexpandjsonpath;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD})
+public @interface RegExpAndJsonPath {
+    /**
+     * Regular expression and path for the desired json element
+     */
+    String[] value();
+}

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/common/converters/regexpandjsonpath/converter/RegExpAndJsonPathConverterFactory.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/common/converters/regexpandjsonpath/converter/RegExpAndJsonPathConverterFactory.java
@@ -1,0 +1,58 @@
+package com.liskovsoft.youtubeapi.common.converters.regexpandjsonpath.converter;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.ParseContext;
+import com.jayway.jsonpath.spi.json.GsonJsonProvider;
+import com.jayway.jsonpath.spi.mapper.GsonMappingProvider;
+import com.liskovsoft.youtubeapi.common.converters.regexpandjsonpath.typeadapter.RegExpAndJsonPathTypeAdapter;
+import okhttp3.RequestBody;
+import okhttp3.ResponseBody;
+import retrofit2.Converter;
+import retrofit2.Retrofit;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+public final class RegExpAndJsonPathConverterFactory extends Converter.Factory {
+    private final ParseContext mParser;
+
+    public static RegExpAndJsonPathConverterFactory create() {
+        Configuration conf = Configuration
+                .builder()
+                .mappingProvider(new GsonMappingProvider())
+                .jsonProvider(new GsonJsonProvider())
+                .build();
+
+        ParseContext parser = JsonPath.using(conf);
+
+        return create(parser);
+    }
+
+    private static RegExpAndJsonPathConverterFactory create(ParseContext parser) {
+        if (parser == null) {
+            throw new NullPointerException("Improper initialization of converter factory");
+        }
+
+        return new RegExpAndJsonPathConverterFactory(parser);
+    }
+
+    private RegExpAndJsonPathConverterFactory(ParseContext parser) {
+        mParser = parser;
+    }
+
+    @Override
+    public Converter<ResponseBody, ?> responseBodyConverter(Type type,
+                                                            Annotation[] annotations,
+                                                            Retrofit retrofit) {
+        return new RegExpAndJsonPathResponseBodyConverter<>(new RegExpAndJsonPathTypeAdapter<>(mParser, type));
+    }
+
+    @Override
+    public Converter<?, RequestBody> requestBodyConverter(Type type,
+                                                          Annotation[] parameterAnnotations,
+                                                          Annotation[] methodAnnotations,
+                                                          Retrofit retrofit) {
+        return new RegExpAndJsonPathRequestBodyConverter<>(new RegExpAndJsonPathTypeAdapter<>(mParser, type));
+    }
+}

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/common/converters/regexpandjsonpath/converter/RegExpAndJsonPathRequestBodyConverter.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/common/converters/regexpandjsonpath/converter/RegExpAndJsonPathRequestBodyConverter.java
@@ -1,0 +1,25 @@
+package com.liskovsoft.youtubeapi.common.converters.regexpandjsonpath.converter;
+
+import android.util.Log;
+import com.liskovsoft.youtubeapi.common.converters.regexpandjsonpath.typeadapter.RegExpAndJsonPathTypeAdapter;
+import okhttp3.MediaType;
+import okhttp3.RequestBody;
+import retrofit2.Converter;
+import retrofit2.internal.EverythingIsNonNull;
+
+public class RegExpAndJsonPathRequestBodyConverter<T> implements Converter<T, RequestBody> {
+    private static final String TAG = RegExpAndJsonPathRequestBodyConverter.class.getSimpleName();
+    private static final MediaType MEDIA_TYPE = MediaType.get("text/plain; charset=UTF-8");
+    private final RegExpAndJsonPathTypeAdapter<T> mAdapter;
+
+    public RegExpAndJsonPathRequestBodyConverter(RegExpAndJsonPathTypeAdapter<T> adapter) {
+        mAdapter = adapter;
+    }
+
+    @EverythingIsNonNull
+    @Override
+    public RequestBody convert(T value) {
+        Log.d(TAG, value.toString());
+        return RequestBody.create(MEDIA_TYPE, value.toString());
+    }
+}

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/common/converters/regexpandjsonpath/converter/RegExpAndJsonPathResponseBodyConverter.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/common/converters/regexpandjsonpath/converter/RegExpAndJsonPathResponseBodyConverter.java
@@ -1,0 +1,22 @@
+package com.liskovsoft.youtubeapi.common.converters.regexpandjsonpath.converter;
+
+import com.liskovsoft.youtubeapi.common.converters.regexpandjsonpath.typeadapter.RegExpAndJsonPathTypeAdapter;
+import okhttp3.ResponseBody;
+import retrofit2.Converter;
+
+final class RegExpAndJsonPathResponseBodyConverter<T> implements Converter<ResponseBody, T> {
+    private final RegExpAndJsonPathTypeAdapter<T> mAdapter;
+
+    RegExpAndJsonPathResponseBodyConverter(RegExpAndJsonPathTypeAdapter<T> adapter) {
+        mAdapter = adapter;
+    }
+
+    @Override
+    public T convert(ResponseBody value) {
+        try {
+            return mAdapter.read(value.byteStream());
+        } finally {
+            value.close();
+        }
+    }
+}

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/common/converters/regexpandjsonpath/typeadapter/RegExpAndJsonPathTypeAdapter.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/common/converters/regexpandjsonpath/typeadapter/RegExpAndJsonPathTypeAdapter.java
@@ -1,0 +1,266 @@
+package com.liskovsoft.youtubeapi.common.converters.regexpandjsonpath.typeadapter;
+
+import android.content.Context;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.ParseContext;
+import com.jayway.jsonpath.PathNotFoundException;
+import com.liskovsoft.sharedutils.helpers.FileHelpers;
+import com.liskovsoft.sharedutils.helpers.Helpers;
+import com.liskovsoft.sharedutils.helpers.MessageHelpers;
+import com.liskovsoft.sharedutils.mylogger.Log;
+import com.liskovsoft.sharedutils.prefs.GlobalPreferences;
+import com.liskovsoft.youtubeapi.common.converters.regexpandjsonpath.RegExpAndJsonPath;
+import com.liskovsoft.youtubeapi.common.helpers.ReflectionHelper;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class RegExpAndJsonPathTypeAdapter<T> {
+    private static final String TAG = RegExpAndJsonPathTypeAdapter.class.getSimpleName();
+    private final ParseContext mParser;
+    private final Class<?> mType;
+
+    public RegExpAndJsonPathTypeAdapter(ParseContext parser, Class<?> type) {
+        mParser = parser;
+        mType = type;
+    }
+
+    public RegExpAndJsonPathTypeAdapter(ParseContext parser, Type type) {
+        mParser = parser;
+        mType = (Class<?>) type;
+    }
+
+    private Class<?> getGenericType() {
+        return mType;
+    }
+
+    @SuppressWarnings("unchecked")
+    public final T read(InputStream is) {
+        // Can't use Scanner(is) here. Because pattern should be matched multiple times.
+        String regExpContent = Helpers.toString(is);
+
+        return (T) readType(getGenericType(), regExpContent);
+    }
+
+    private Object readType(Class<?> type, String regExpContent) {
+        if (type == null || regExpContent == null) {
+            return null;
+        }
+
+        Object obj = null;
+        boolean unset = false;
+
+        String regExpVal = null;
+
+        List<Field> fields = ReflectionHelper.getAllFields(type);
+        Field regExpField = fields.get(0);
+        String[] annotations = getRegExpAndJsonPath(regExpField);
+
+        try {
+            Constructor<?> constructor = type.getConstructor();
+            obj = constructor.newInstance();
+
+            regExpField.setAccessible(true);
+            String path = annotations[0];
+
+            try {
+                Pattern pattern = Pattern.compile(path);
+                Matcher matcher = pattern.matcher(regExpContent);
+
+                if (matcher.find()) {
+                    if (matcher.groupCount() >= 1) {
+                        regExpVal = matcher.group(1);
+                    } else {
+                        regExpVal = matcher.group(0); // all match
+                    }
+                }
+
+            } catch (PathNotFoundException e) {
+                Log.e(TAG, type.getSimpleName() + ": " + e.getMessage());
+            }
+
+            if (regExpVal == null && !ReflectionHelper.isNullable(regExpField)) {
+                unset = true; // at least one required field is unset
+            }
+        } catch (Exception e) {
+            unset = true; // at least one field is unset
+            e.printStackTrace();
+        }
+
+        if (unset) {
+            ReflectionHelper.dumpDebugInfo(type, regExpContent);
+        }
+
+        InputStream is = new ByteArrayInputStream(regExpVal.getBytes(Charset.forName("UTF-8")));
+
+        String jsonContent = null;
+
+        String jsonPath = annotations[1];
+
+        if (jsonPath != null) { // annotation on the same collection class
+            DocumentContext parser = mParser.parse(is);
+            try {
+                jsonContent = parser.read(jsonPath).toString();
+            } catch (PathNotFoundException e) {
+                Log.e(TAG, e.getMessage());
+            }
+        } else { // annotation on field
+            jsonContent = Helpers.toString(is);
+        }
+
+        T result = (T) readJsonPathType(getGenericType(), jsonContent);
+
+        if (result == null) {
+            // Dump root object
+            ReflectionHelper.dumpDebugInfo(getGenericType(), jsonContent);
+        }
+
+        return result;
+    }
+
+    private Object readJsonPathType(Class<?> type, String jsonContent) {
+        if (type == null || jsonContent == null) {
+            return null;
+        }
+
+        Object obj = null;
+
+        try {
+            Constructor<?> constructor = type.getConstructor();
+            obj = constructor.newInstance();
+
+            DocumentContext parser = mParser.parse(jsonContent);
+
+            List<Field> fields = ReflectionHelper.getAllFields(type);
+
+            for (Field field : fields) {
+                processField(field, obj, type, parser);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return obj;
+    }
+
+    private boolean processField(Field field, Object obj, Class<?> type, DocumentContext parser) {
+        boolean done = false;
+        field.setAccessible(true);
+        String[] jsonPaths = getRegExpAndJsonPath(field);
+
+        if (jsonPaths == null) {
+            return false;
+        }
+
+        String[] jsonPath = Arrays.copyOfRange(jsonPaths, 1, jsonPaths.length);
+
+        Object jsonVal = null;
+
+        for (String path : jsonPath) {
+            try {
+                jsonVal = parser.read(path);
+                break;
+            } catch (PathNotFoundException e) {
+                Log.d(TAG, type.getSimpleName() + ": Path not found: " + path);
+            }
+        }
+
+        if (jsonVal == null) {
+            return false;
+        }
+
+        try {
+            if (jsonVal instanceof JsonArray) {
+                List<Object> list = null;
+                Class<?> myType = ReflectionHelper.getGenericParamType(field);
+
+                if (myType == null) {
+                    throw new IllegalStateException("Please, supply generic field for the list type: " + field);
+                }
+
+                for (Object jsonObj : (JsonArray) jsonVal) {
+                    Object item;
+
+                    if (jsonObj instanceof JsonPrimitive) {
+                        item = parsePrimitive((JsonPrimitive) jsonObj);
+                    } else {
+                        item = readJsonPathType(myType, jsonObj.toString());
+                    }
+
+                    if (item != null) {
+                        if (list == null) {
+                            list = new ArrayList<>();
+                        }
+
+                        list.add(item);
+                    }
+                }
+
+                field.set(obj, list);
+            } else if (jsonVal instanceof JsonPrimitive) {
+                Object val = parsePrimitive((JsonPrimitive) jsonVal);
+
+                field.set(obj, val);
+            } else if (jsonVal instanceof JsonObject) {
+                Object val = readType(field.getType(), jsonVal.toString());
+                field.set(obj, val);
+            }
+
+            done = field.get(obj) != null; // field is set
+        } catch (IllegalArgumentException e) {
+            Log.d(TAG, "%s: Incompatible json value found %s. Same path on different types?", field.getType().getSimpleName(), jsonVal);
+        } catch (IllegalAccessException e) {
+            Log.d(TAG, "%s: Illegal access with value %s.", field.getType().getSimpleName(), jsonVal);
+        }
+
+        return done;
+    }
+
+    private String[] getRegExpAndJsonPath(Field field) {
+        Annotation[] annotations = field.getAnnotations();
+
+        return getRegExpAndJsonPath(annotations);
+    }
+
+    private String[] getRegExpAndJsonPath(Annotation[] annotations) {
+        for (Annotation annotation : annotations) {
+            if (annotation instanceof RegExpAndJsonPath) {
+                return ((RegExpAndJsonPath) annotation).value();
+            }
+        }
+
+        return null;
+    }
+
+    private Object parsePrimitive(JsonPrimitive jsonVal) {
+        Object val;
+
+        if (jsonVal.isNumber()) {
+            if (jsonVal.toString().contains(".")) {
+                val = jsonVal.getAsFloat(); // Float
+            } else {
+                val = jsonVal.getAsInt(); // Integer
+            }
+        } else if (jsonVal.isBoolean()) {
+            val = jsonVal.getAsBoolean(); // Boolean
+        } else {
+            val = jsonVal.getAsString(); // String
+        }
+
+        return val;
+    }
+}

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/common/helpers/RetrofitHelper.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/common/helpers/RetrofitHelper.java
@@ -19,6 +19,7 @@ import com.liskovsoft.youtubeapi.common.converters.jsonpath.typeadapter.JsonPath
 import com.liskovsoft.youtubeapi.common.converters.jsonpath.typeadapter.JsonPathTypeAdapter;
 import com.liskovsoft.youtubeapi.common.converters.querystring.converter.QueryStringConverterFactory;
 import com.liskovsoft.youtubeapi.common.converters.regexp.converter.RegExpConverterFactory;
+import com.liskovsoft.youtubeapi.common.converters.regexpandjsonpath.converter.RegExpAndJsonPathConverterFactory;
 import com.liskovsoft.youtubeapi.common.interceptors.UnzippingInterceptor;
 import okhttp3.Dns;
 import okhttp3.HttpUrl;
@@ -66,6 +67,10 @@ public class RetrofitHelper {
 
     public static <T> T withRegExp(Class<T> clazz) {
         return buildRetrofit(RegExpConverterFactory.create()).create(clazz);
+    }
+
+    public static <T> T withRegExpAndJsonPath(Class<T> clazz) {
+        return buildRetrofit(RegExpAndJsonPathConverterFactory.create()).create(clazz);
     }
 
     public static <T> T get(Call<T> wrapper) {

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/pageinfo/PageInfoServiceBase.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/pageinfo/PageInfoServiceBase.java
@@ -1,0 +1,11 @@
+package com.liskovsoft.youtubeapi.pageinfo;
+
+import com.liskovsoft.youtubeapi.app.AppService;
+
+public abstract class PageInfoServiceBase {
+    protected final AppService mAppService;
+
+    protected PageInfoServiceBase() {
+        mAppService = AppService.instance();
+    }
+}

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/pageinfo/V1/PageInfoManagerSigned.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/pageinfo/V1/PageInfoManagerSigned.java
@@ -1,0 +1,36 @@
+package com.liskovsoft.youtubeapi.pageinfo.V1;
+
+import com.liskovsoft.youtubeapi.app.AppConstants;
+import com.liskovsoft.youtubeapi.pageinfo.models.PageInfo;
+
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Query;
+
+/**
+ * NOTE: html5=1 is required. Otherwise you'll get 404 error "This is not a P3P policy!"<br/>
+ * Unlock Gemini Man 4K: https://www.youtube.com/get_page_info?ps=leanback&el=leanback&eurl=https%3A%2F%2Fwww.youtube.com%2Ftv<br/>
+ * Unlock age restricted pages: https://www.youtube.com/get_page_info?ps=default&eurl=https%3A%2F%2Fwww.youtube.com%2Ftv
+ */
+public interface PageInfoManagerSigned {
+    @GET("https://www.youtube.com/watch?bpctr=9999999999&has_verified=1")
+    Call<PageInfo> getPageInfo(@Query("video_id") String videoId, @Query("access_token") String token, @Query("hl") String lang);
+
+    /**
+     * Unlock live hls streams
+     */
+    @GET("https://www.youtube.com/watch?bpctr=9999999999&has_verified=1")
+    Call<PageInfo> getPageInfoHls(@Query("video_id") String videoId, @Query("access_token") String token, @Query("hl") String lang);
+
+    /**
+     * Unlock age restricted pages
+     */
+    @GET("https://www.youtube.com/watch?bpctr=9999999999&has_verified=1")
+    Call<PageInfo> getPageInfoRestricted(@Query("video_id") String videoId, @Query("access_token") String token, @Query("hl") String lang);
+
+    /**
+     * Unlock personal pages: <code>c=TVHTML5&cver=7.20201103.00.00</code><br/>
+     */
+    @GET("https://www.youtube.com/watch?bpctr=9999999999&has_verified=1")
+    Call<PageInfo> getPageInfoRegular(@Query("video_id") String videoId, @Query("access_token") String token, @Query("hl") String lang);
+}

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/pageinfo/V1/PageInfoManagerUnsigned.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/pageinfo/V1/PageInfoManagerUnsigned.java
@@ -1,0 +1,25 @@
+package com.liskovsoft.youtubeapi.pageinfo.V1;
+
+import com.liskovsoft.youtubeapi.app.AppConstants;
+import com.liskovsoft.youtubeapi.pageinfo.models.PageInfo;
+
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Query;
+
+public interface PageInfoManagerUnsigned {
+    @GET("https://www.youtube.com/watch?bpctr=9999999999&has_verified=1")
+    Call<PageInfo> getPageInfo(@Query("v") String videoId, @Query("hl") String lang);
+
+    /**
+     * Good for live translations
+     */
+    @GET("https://www.youtube.com/watch?bpctr=9999999999&has_verified=1")
+    Call<PageInfo> getPageInfoHls(@Query("v") String videoId, @Query("hl") String lang);
+
+    /**
+     * Good for age restricted pages
+     */
+    @GET("https://www.youtube.com/watch?has_verified=1")
+    Call<PageInfo> getPageInfoRestricted(@Query("v") String videoId, @Query("hl") String lang);
+}

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/pageinfo/V1/PageInfoServiceSigned.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/pageinfo/V1/PageInfoServiceSigned.java
@@ -1,0 +1,52 @@
+package com.liskovsoft.youtubeapi.pageinfo.V1;
+
+import com.liskovsoft.sharedutils.mylogger.Log;
+import com.liskovsoft.youtubeapi.common.helpers.RetrofitHelper;
+import com.liskovsoft.youtubeapi.common.helpers.ServiceHelper;
+import com.liskovsoft.youtubeapi.common.locale.LocaleManager;
+import com.liskovsoft.youtubeapi.pageinfo.PageInfoServiceBase;
+import com.liskovsoft.youtubeapi.pageinfo.models.PageInfo;
+import com.liskovsoft.youtubeapi.videoinfo.V1.VideoInfoServiceSigned;
+
+import retrofit2.Call;
+
+public class PageInfoServiceSigned extends PageInfoServiceBase {
+    private static PageInfoServiceSigned sInstance;
+    private final PageInfoManagerSigned mPageInfoManagerSigned;
+    private final LocaleManager mLocaleManager;
+
+    private PageInfoServiceSigned() {
+        mPageInfoManagerSigned = RetrofitHelper.withRegExpAndJsonPath(PageInfoManagerSigned.class);
+        mLocaleManager = LocaleManager.instance();
+    }
+
+    public static PageInfoServiceSigned instance() {
+        if (sInstance == null) {
+            sInstance = new PageInfoServiceSigned();
+        }
+
+        return sInstance;
+    }
+
+    public PageInfo getPageInfo(String videoId, String authorization) {
+        return getPageInfoHls(videoId, authorization);
+    }
+
+    private PageInfo getPageInfoHls(String videoId, String authorization) {
+        Call<PageInfo> wrapper = mPageInfoManagerSigned.getPageInfoHls(videoId, ServiceHelper.getToken(authorization), mLocaleManager.getLanguage());
+
+        return RetrofitHelper.get(wrapper);
+    }
+
+    private PageInfo getPageInfoRegular(String videoId, String authorization) {
+        Call<PageInfo> wrapper = mPageInfoManagerSigned.getPageInfoRegular(videoId, ServiceHelper.getToken(authorization), mLocaleManager.getLanguage());
+
+        return RetrofitHelper.get(wrapper);
+    }
+
+    private PageInfo getPageInfoRestricted(String videoId, String authorization) {
+        Call<PageInfo> wrapper = mPageInfoManagerSigned.getPageInfoRestricted(videoId, ServiceHelper.getToken(authorization), mLocaleManager.getLanguage());
+
+        return RetrofitHelper.get(wrapper);
+    }
+}

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/pageinfo/V1/PageInfoServiceUnsigned.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/pageinfo/V1/PageInfoServiceUnsigned.java
@@ -1,0 +1,44 @@
+package com.liskovsoft.youtubeapi.pageinfo.V1;
+
+import com.liskovsoft.sharedutils.mylogger.Log;
+import com.liskovsoft.youtubeapi.common.helpers.RetrofitHelper;
+import com.liskovsoft.youtubeapi.common.locale.LocaleManager;
+import com.liskovsoft.youtubeapi.pageinfo.PageInfoServiceBase;
+import com.liskovsoft.youtubeapi.pageinfo.models.PageInfo;
+
+import retrofit2.Call;
+
+public class PageInfoServiceUnsigned extends PageInfoServiceBase {
+    private static PageInfoServiceUnsigned sInstance;
+    private final PageInfoManagerUnsigned mPageInfoManagerUnsigned;
+    private final LocaleManager mLocaleManager;
+
+    private PageInfoServiceUnsigned() {
+        mPageInfoManagerUnsigned = RetrofitHelper.withRegExpAndJsonPath(PageInfoManagerUnsigned.class);
+        mLocaleManager = LocaleManager.instance();
+    }
+
+    public static PageInfoServiceUnsigned instance() {
+        if (sInstance == null) {
+            sInstance = new PageInfoServiceUnsigned();
+        }
+
+        return sInstance;
+    }
+
+    public PageInfo getPageInfo(String videoId) {
+        return getPageInfoHls(videoId);
+    }
+
+    private PageInfo getPageInfoHls(String videoId) {
+        Call<PageInfo> wrapper = mPageInfoManagerUnsigned.getPageInfoHls(videoId, mLocaleManager.getLanguage());
+
+        return RetrofitHelper.get(wrapper);
+    }
+
+    private PageInfo getPageInfoRestricted(String videoId) {
+        Call<PageInfo> wrapper = mPageInfoManagerUnsigned.getPageInfoRestricted(videoId, mLocaleManager.getLanguage());
+
+        return RetrofitHelper.get(wrapper);
+    }
+}

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/pageinfo/models/PageInfo.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/pageinfo/models/PageInfo.java
@@ -1,0 +1,29 @@
+package com.liskovsoft.youtubeapi.pageinfo.models;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.ParseContext;
+import com.jayway.jsonpath.spi.json.GsonJsonProvider;
+import com.jayway.jsonpath.spi.mapper.GsonMappingProvider;
+import com.liskovsoft.sharedutils.mylogger.Log;
+import com.liskovsoft.youtubeapi.common.converters.jsonpath.converter.JsonPathConverterFactory;
+import com.liskovsoft.youtubeapi.common.converters.jsonpath.typeadapter.JsonPathSkipTypeAdapter;
+import com.liskovsoft.youtubeapi.common.converters.regexpandjsonpath.RegExpAndJsonPath;
+import com.liskovsoft.youtubeapi.common.converters.jsonpath.typeadapter.JsonPathTypeAdapter;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.util.List;
+
+public class PageInfo {
+
+    @RegExpAndJsonPath({"translationLanguages.:(.+?\\])", "$[*]"})
+    private List<TranslationLanguage> mTranslationLanguages;
+
+    public List<TranslationLanguage> getTranslationLanguages() {
+        return mTranslationLanguages;
+    }
+}

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/pageinfo/models/TranslationLanguage.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/pageinfo/models/TranslationLanguage.java
@@ -1,0 +1,23 @@
+package com.liskovsoft.youtubeapi.pageinfo.models;
+
+import com.liskovsoft.youtubeapi.common.converters.regexpandjsonpath.RegExpAndJsonPath;
+import com.liskovsoft.youtubeapi.common.models.V2.TextItem;
+
+public class TranslationLanguage {
+    /**
+     * Example: "en"
+     */
+    @RegExpAndJsonPath({"()", "$.languageCode"})
+    private String mLanguageCode;
+    @RegExpAndJsonPath({"()", "$.languageName.simpleText"})
+    private String mLanguageName;
+
+    public String getLanguageCode() {
+        return mLanguageCode;
+    }
+
+    public String getLanguageName() {
+        return mLanguageName;
+    }
+
+}

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/service/YouTubeMediaItemService.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/service/YouTubeMediaItemService.java
@@ -25,6 +25,7 @@ import com.liskovsoft.youtubeapi.service.data.YouTubeVideoPlaylistInfo;
 import com.liskovsoft.youtubeapi.service.internal.MediaItemServiceInt;
 import com.liskovsoft.youtubeapi.service.internal.YouTubeMediaItemServiceSigned;
 import com.liskovsoft.youtubeapi.service.internal.YouTubeMediaItemServiceUnsigned;
+import com.liskovsoft.youtubeapi.pageinfo.models.PageInfo;
 import com.liskovsoft.youtubeapi.videoinfo.models.VideoInfo;
 import io.reactivex.Observable;
 
@@ -76,8 +77,9 @@ public class YouTubeMediaItemService implements MediaItemService {
         checkSigned();
 
         VideoInfo videoInfo = mMediaItemManagerReal.getVideoInfo(videoId, clickTrackingParams);
+        PageInfo pageInfo = mMediaItemManagerReal.getPageInfo(videoId);
 
-        YouTubeMediaItemFormatInfo formatInfo = YouTubeMediaItemFormatInfo.from(videoInfo);
+        YouTubeMediaItemFormatInfo formatInfo = YouTubeMediaItemFormatInfo.from(videoInfo, pageInfo);
 
         saveInCache(formatInfo);
 

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/service/data/YouTubeMediaItemFormatInfo.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/service/data/YouTubeMediaItemFormatInfo.java
@@ -9,8 +9,10 @@ import com.liskovsoft.youtubeapi.formatbuilders.mpdbuilder.YouTubeMPDBuilder;
 import com.liskovsoft.youtubeapi.formatbuilders.storyboard.YouTubeStoryParser;
 import com.liskovsoft.youtubeapi.formatbuilders.storyboard.YouTubeStoryParser.Storyboard;
 import com.liskovsoft.youtubeapi.videoinfo.models.CaptionTrack;
+import com.liskovsoft.youtubeapi.pageinfo.models.TranslationLanguage;
 import com.liskovsoft.youtubeapi.videoinfo.models.VideoDetails;
 import com.liskovsoft.youtubeapi.videoinfo.models.VideoInfo;
+import com.liskovsoft.youtubeapi.pageinfo.models.PageInfo;
 import com.liskovsoft.youtubeapi.videoinfo.models.formats.AdaptiveVideoFormat;
 import com.liskovsoft.youtubeapi.videoinfo.models.formats.RegularVideoFormat;
 import io.reactivex.Observable;
@@ -48,8 +50,8 @@ public class YouTubeMediaItemFormatInfo implements MediaItemFormatInfo {
         mCreatedTimeMs = System.currentTimeMillis();
     }
 
-    public static YouTubeMediaItemFormatInfo from(VideoInfo videoInfo) {
-        if (videoInfo == null) {
+    public static YouTubeMediaItemFormatInfo from(VideoInfo videoInfo, PageInfo pageInfo) {
+        if (videoInfo == null || pageInfo == null) {
             return null;
         }
 
@@ -96,12 +98,19 @@ public class YouTubeMediaItemFormatInfo implements MediaItemFormatInfo {
         formatInfo.mIsStreamSeekable = videoInfo.isHfr();
 
         List<CaptionTrack> captionTracks = videoInfo.getCaptionTracks();
+        List<TranslationLanguage> translationLanguages = pageInfo.getTranslationLanguages();
 
         if (captionTracks != null) {
             formatInfo.mSubtitles = new ArrayList<>();
 
             for (CaptionTrack track : captionTracks) {
                 formatInfo.mSubtitles.add(YouTubeMediaSubtitle.from(track));
+
+                if (translationLanguages != null) {
+                    for (TranslationLanguage language : translationLanguages) {
+                        formatInfo.mSubtitles.add(YouTubeMediaSubtitle.from(language, track));
+                    }
+                }
             }
         }
 

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/service/data/YouTubeMediaSubtitle.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/service/data/YouTubeMediaSubtitle.java
@@ -2,6 +2,7 @@ package com.liskovsoft.youtubeapi.service.data;
 
 import com.liskovsoft.mediaserviceinterfaces.data.MediaSubtitle;
 import com.liskovsoft.youtubeapi.videoinfo.models.CaptionTrack;
+import com.liskovsoft.youtubeapi.pageinfo.models.TranslationLanguage;
 
 public class YouTubeMediaSubtitle implements MediaSubtitle {
     private String mBaseUrl;
@@ -21,6 +22,22 @@ public class YouTubeMediaSubtitle implements MediaSubtitle {
         subtitle.mLanguageCode = track.getLanguageCode();
         subtitle.mVssId = track.getVssId();
         subtitle.mName = track.getName();
+        subtitle.mType = track.getType();
+        subtitle.mMimeType = track.getMimeType();
+        subtitle.mCodecs = track.getCodecs();
+
+        return subtitle;
+    }
+
+    public static MediaSubtitle from(TranslationLanguage language, CaptionTrack track) {
+        YouTubeMediaSubtitle subtitle = new YouTubeMediaSubtitle();
+        String languageCode = language.getLanguageCode();
+
+        subtitle.mBaseUrl = track.getBaseUrl() + "&tlang=" + languageCode;
+        subtitle.mIsTranslatable = false;
+        subtitle.mLanguageCode = languageCode;
+        subtitle.mVssId = track.getVssId() + "." + languageCode;
+        subtitle.mName = language.getLanguageName();
         subtitle.mType = track.getType();
         subtitle.mMimeType = track.getMimeType();
         subtitle.mCodecs = track.getCodecs();

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/service/internal/MediaItemServiceInt.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/service/internal/MediaItemServiceInt.java
@@ -3,6 +3,7 @@ package com.liskovsoft.youtubeapi.service.internal;
 import com.liskovsoft.youtubeapi.next.v1.result.WatchNextResult;
 import com.liskovsoft.youtubeapi.next.v1.result.WatchNextResultContinuation;
 import com.liskovsoft.youtubeapi.playlist.models.PlaylistsResult;
+import com.liskovsoft.youtubeapi.pageinfo.models.PageInfo;
 import com.liskovsoft.youtubeapi.videoinfo.models.VideoInfo;
 
 public interface MediaItemServiceInt {
@@ -10,6 +11,7 @@ public interface MediaItemServiceInt {
     WatchNextResult getWatchNextResult(String videoId, String playlistId, int playlistIndex, String playlistParams);
     WatchNextResultContinuation continueWatchNext(String nextKey);
     VideoInfo getVideoInfo(String videoId, String clickTrackingParams);
+    PageInfo getPageInfo(String videoId);
     void updateHistoryPosition(String videoId, String lengthSec,
                                String eventId, String vmData, float positionSec);
     void setLike(String videoId);

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/service/internal/YouTubeMediaItemServiceSigned.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/service/internal/YouTubeMediaItemServiceSigned.java
@@ -12,6 +12,9 @@ import com.liskovsoft.youtubeapi.service.YouTubeSignInService;
 import com.liskovsoft.youtubeapi.track.TrackingService;
 import com.liskovsoft.youtubeapi.videoinfo.V2.VideoInfoServiceSigned;
 import com.liskovsoft.youtubeapi.videoinfo.V2.VideoInfoServiceUnsigned;
+import com.liskovsoft.youtubeapi.pageinfo.models.PageInfo;
+import com.liskovsoft.youtubeapi.pageinfo.V1.PageInfoServiceSigned;
+import com.liskovsoft.youtubeapi.pageinfo.V1.PageInfoServiceUnsigned;
 import com.liskovsoft.youtubeapi.videoinfo.models.VideoInfo;
 
 public class YouTubeMediaItemServiceSigned implements MediaItemServiceInt {
@@ -21,6 +24,7 @@ public class YouTubeMediaItemServiceSigned implements MediaItemServiceInt {
     private final YouTubeSignInService mSignInManager;
     private final TrackingService mTrackingService;
     private final VideoInfoServiceSigned mVideoInfoServiceSigned;
+    private final PageInfoServiceSigned mPageInfoServiceSigned;
     private final ActionsService mActionsService;
     private final PlaylistService mPlaylistService;
     private final FeedbackService mFeedbackService;
@@ -30,6 +34,7 @@ public class YouTubeMediaItemServiceSigned implements MediaItemServiceInt {
         mSignInManager = YouTubeSignInService.instance();
         mTrackingService = TrackingService.instance();
         mVideoInfoServiceSigned = VideoInfoServiceSigned.instance();
+        mPageInfoServiceSigned = PageInfoServiceSigned.instance();
         mActionsService = ActionsService.instance();
         mPlaylistService = PlaylistService.instance();
         mFeedbackService = FeedbackService.instance();
@@ -84,6 +89,18 @@ public class YouTubeMediaItemServiceSigned implements MediaItemServiceInt {
         // Fix no playback bug (temporal fix)
         if (result == null || !result.isValid()) {
             result = VideoInfoServiceUnsigned.instance().getVideoInfo(videoId, clickTrackingParams);
+        }
+
+        return result;
+    }
+
+    @Override
+    public PageInfo getPageInfo(String videoId) {
+        PageInfo result = mPageInfoServiceSigned.getPageInfo(videoId, mSignInManager.getAuthorizationHeader());
+
+        // Fix no playback bug (temporal fix)
+        if (result == null) {
+            result = PageInfoServiceUnsigned.instance().getPageInfo(videoId);
         }
 
         return result;

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/service/internal/YouTubeMediaItemServiceUnsigned.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/service/internal/YouTubeMediaItemServiceUnsigned.java
@@ -3,18 +3,22 @@ package com.liskovsoft.youtubeapi.service.internal;
 import com.liskovsoft.youtubeapi.next.v1.WatchNextServiceUnsigned;
 import com.liskovsoft.youtubeapi.next.v1.result.WatchNextResult;
 import com.liskovsoft.youtubeapi.next.v1.result.WatchNextResultContinuation;
+import com.liskovsoft.youtubeapi.pageinfo.models.PageInfo;
 import com.liskovsoft.youtubeapi.playlist.models.PlaylistsResult;
 import com.liskovsoft.youtubeapi.videoinfo.V2.VideoInfoServiceUnsigned;
+import com.liskovsoft.youtubeapi.pageinfo.V1.PageInfoServiceUnsigned;
 import com.liskovsoft.youtubeapi.videoinfo.models.VideoInfo;
 
 public class YouTubeMediaItemServiceUnsigned implements MediaItemServiceInt {
     private static YouTubeMediaItemServiceUnsigned sInstance;
     private final WatchNextServiceUnsigned mWatchNextServiceUnsigned;
     private final VideoInfoServiceUnsigned mVideoInfoServiceUnsigned;
+    private final PageInfoServiceUnsigned mPageInfoServiceUnsigned;
 
     private YouTubeMediaItemServiceUnsigned() {
        mWatchNextServiceUnsigned = WatchNextServiceUnsigned.instance();
        mVideoInfoServiceUnsigned = VideoInfoServiceUnsigned.instance();
+       mPageInfoServiceUnsigned = PageInfoServiceUnsigned.instance();
     }
 
     public static YouTubeMediaItemServiceUnsigned instance() {
@@ -48,6 +52,11 @@ public class YouTubeMediaItemServiceUnsigned implements MediaItemServiceInt {
     @Override
     public VideoInfo getVideoInfo(String videoId, String clickTrackingParams) {
         return mVideoInfoServiceUnsigned.getVideoInfo(videoId, clickTrackingParams);
+    }
+
+    @Override
+    public PageInfo getPageInfo(String videoId) {
+        return mPageInfoServiceUnsigned.getPageInfo(videoId);
     }
 
     @Override


### PR DESCRIPTION
Based on yt-dlp's implementation ([yt_dlp/extractor/youtube.py#L3637-L3699](https://github.com/yt-dlp/yt-dlp/blob/96623ab5c6cea59c22395a47f00a13d334de6106/yt_dlp/extractor/youtube.py#L3637-L3699))

- [x] Download automatically-translated subtitles
- [ ]  Create UI button in subtitle menu to select automatically translated subtitles
- [ ] Separate automatically-translated subtitle tracks from human-generated and auto-generated subtitle tracks
- [x] Support restricted videos (workaround: https://github.com/yt-dlp/yt-dlp/pull/3233) (another workaround is to simply append the `tlang` URL parameter at the end of the baseURL's for the subtitles that already exist (since for those ones you already bypassed the age-restriction). However, you would need to keep up with YouTube whenever they change what auto-translated languages are available, and also provide the language names yourself)
- [ ] Clean code (remove uneeded code)
- [ ] Localize to other languages
- [ ] Make system to choose which subtitle to translate from by default (probably the best way is to choose the human-generated translation of the language of the video (which will also have an auto-generated version), and if that doesn't exist, choose the most popular language from the human-generated subtitles (by population), and if there aren't any human-generated subtitles, choose the auto-generated one. This feature would be to have subtitles in the user's chosen language without needing their input. So if they chose Spanish, even if a video didn't have Spanish subtitles, it would show the auto-translated Spanish subtitles by choosing the best non-translated subtitle, and of course showing the human-translated Spanish subtitles if it exists)

Resolves https://github.com/yuliskov/SmartTubeNext/issues/244
Resolves https://github.com/yuliskov/SmartTubeNext/issues/1407
Resolves https://github.com/yuliskov/SmartTubeNext/issues/1741
Resolves https://github.com/yuliskov/SmartTubeNext/issues/1745