### PR TITLE
Added null check for mMetaData.getBadgeStyles() in TileItem

### DIFF
--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/common/models/V2/TileItem.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/common/models/V2/TileItem.java
@@ -157,6 +157,7 @@ public class TileItem {
 
     @Nullable
     private String[] getBadgeStyles() {
-        return mHeader != null ? new String[] {mHeader.getBadgeStyle()} : mMetadata != null ? mMetadata.getBadgeStyles().toArray(new String[]{}) : null;
+        return mHeader != null ? new String[] {mHeader.getBadgeStyle()} :
+                mMetadata != null && mMetadata.getBadgeStyles() != null ? mMetadata.getBadgeStyles().toArray(new String[]{}) : null;
     }
 }


### PR DESCRIPTION
The music section doesn't load correctly for me. It briefly appears, but then disappears.

It looks like there was a recent commit to fix it, but it doesn't seem to work for me:

https://github.com/yuliskov/MediaServiceCore/commit/4648ff6c44d0c6413aa17d6ee42b6fd15c9bdb92

Running with that fix, the error log shows:

```
updateRowsHeader error: Attempt to invoke interface method 'java.lang.Object[] java.util.List.toArray(java.lang.Object[])' on a null object reference
```

After debugging, I found that the previous null check looks to be still required for `mMetadata.getBadgeStyles()`, as well as the new one for `mMetadata`, because that field can also be null.
I've tested this along with the latest commit, `6b601ed`, locally on an Nvidia Shield 2017, and this change allows the section to load for me.

Let me know if you need more information or have any questions.