### PR TITLE
dearrow: remove formatting character

### DIFF
--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/dearrow/DeArrowService.kt
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/dearrow/DeArrowService.kt
@@ -21,7 +21,7 @@ internal object DeArrowService {
                 }
 
                 override fun getTitle(): String? {
-                    return it.titles?.firstOrNull { !(it?.original ?: false) }?.title
+                    return it.titles?.firstOrNull { !(it?.original ?: false) }?.title?.replaceAll(">", "")
                 }
 
                 override fun getThumbnailUrl(): String {


### PR DESCRIPTION
This character is used in some titles to tell the DeArrow formatter which words to leave along. Since text auto-formatting is not implemented, this character can be safely ignored, but needs to be removed from titles.

Example:

> Using the >Apple >Vision >Pro

https://sponsor.ajay.app/api/branding?videoID=dtp6b76pMak