### PR TITLE
403 error fixing

### DIFF
--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/common/helpers/AppClient.kt
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/common/helpers/AppClient.kt
@@ -19,6 +19,7 @@ internal enum class AppClient(
     TV("TVHTML5", "7.20250212.16.00", userAgent = DefaultHeaders.USER_AGENT_TV, referer = "https://www.youtube.com/tv"),
     // Use WEB_EMBEDDED_PLAYER instead of WEB. Some videos have 403 error on WEB.
     WEB_EMBEDDED_PLAYER("WEB_EMBEDDED_PLAYER", "2.20250222.10.01", userAgent = DefaultHeaders.USER_AGENT_WEB, referer = "https://www.youtube.com/"),
+    ANDROID_VR("ANDROID_VR", "1.37", userAgent = DefaultHeaders.USER_AGENT_WEB, referer = "https://www.youtube.com/"),
     WEB("WEB", "2.20250222.10.01", userAgent = DefaultHeaders.USER_AGENT_WEB, referer = "https://www.youtube.com/"),
     MWEB("MWEB", "2.20250213.05.00", userAgent = DefaultHeaders.USER_AGENT_MOBILE_WEB, referer = "https://m.youtube.com/"),
     // Request contains an invalid argument.

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/common/helpers/AppClient.kt
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/common/helpers/AppClient.kt
@@ -17,7 +17,9 @@ internal enum class AppClient(
     val clientScreen: String = CLIENT_SCREEN_WATCH, val params: String? = null, val postData: String? = null
 ) {
     TV("TVHTML5", "7.20250212.16.00", userAgent = DefaultHeaders.USER_AGENT_TV, referer = "https://www.youtube.com/tv"),
-    WEB("WEB", "2.20250213.05.00", userAgent = DefaultHeaders.USER_AGENT_WEB, referer = "https://www.youtube.com/"),
+    // Use WEB_EMBEDDED_PLAYER instead of WEB. Some videos have 403 error on WEB.
+    WEB_EMBEDDED_PLAYER("WEB_EMBEDDED_PLAYER", "2.20250222.10.01", userAgent = DefaultHeaders.USER_AGENT_WEB, referer = "https://www.youtube.com/"),
+    WEB("WEB", "2.20250222.10.01", userAgent = DefaultHeaders.USER_AGENT_WEB, referer = "https://www.youtube.com/"),
     MWEB("MWEB", "2.20250213.05.00", userAgent = DefaultHeaders.USER_AGENT_MOBILE_WEB, referer = "https://m.youtube.com/"),
     // Request contains an invalid argument.
     WEB_CREATOR("WEB_CREATOR", "1.20220726.00.00", userAgent = DefaultHeaders.USER_AGENT_WEB, referer = "https://www.youtube.com/"),

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/videoinfo/V2/VideoInfoApiHelper.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/videoinfo/V2/VideoInfoApiHelper.java
@@ -72,7 +72,7 @@ public class VideoInfoApiHelper {
     private static String createCheckedQuery(AppClient client, String videoId, String clickTrackingParams, String query) {
         // Important: use only for the clients that don't support auth.
         // Otherwise, google suggestions and history won't work (visitor data bug)
-        if ((client == AppClient.WEB || client == AppClient.MWEB) && PoTokenGate.supportsNpPot()) {
+        if ((client == AppClient.WEB || client == AppClient.MWEB || client == AppClient.WEB_EMBEDDED_PLAYER) && PoTokenGate.supportsNpPot()) {
             LocaleManager localeManager = LocaleManager.instance();
             return new PostDataBuilder(client)
                     .setType(PostDataType.Player)

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/videoinfo/V2/VideoInfoApiHelper.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/videoinfo/V2/VideoInfoApiHelper.java
@@ -72,7 +72,7 @@ public class VideoInfoApiHelper {
     private static String createCheckedQuery(AppClient client, String videoId, String clickTrackingParams, String query) {
         // Important: use only for the clients that don't support auth.
         // Otherwise, google suggestions and history won't work (visitor data bug)
-        if ((client == AppClient.WEB || client == AppClient.MWEB || client == AppClient.WEB_EMBEDDED_PLAYER) && PoTokenGate.supportsNpPot()) {
+        if ((client == AppClient.WEB || client == AppClient.MWEB || client == AppClient.WEB_EMBEDDED_PLAYER || client == AppClient.ANDROID_VR) && PoTokenGate.supportsNpPot()) {
             LocaleManager localeManager = LocaleManager.instance();
             return new PostDataBuilder(client)
                     .setType(PostDataType.Player)

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/videoinfo/V2/VideoInfoService.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/videoinfo/V2/VideoInfoService.java
@@ -37,6 +37,7 @@ public class VideoInfoService extends VideoInfoServiceBase {
     private final static int VIDEO_INFO_IOS = 5;
     private final static int VIDEO_INFO_EMBED = 6;
     private final static int WEB_EMBEDDED_PLAYER = 7;
+    private final static int ANDROID_VR = 8;
     private final static Integer[] VIDEO_INFO_TYPE_LIST = {
             //VIDEO_INFO_TV, VIDEO_INFO_IOS, VIDEO_INFO_EMBED, VIDEO_INFO_MWEB, VIDEO_INFO_ANDROID, VIDEO_INFO_INITIAL, VIDEO_INFO_WEB
             //VIDEO_INFO_WEB, VIDEO_INFO_MWEB, VIDEO_INFO_INITIAL, VIDEO_INFO_TV, VIDEO_INFO_IOS, VIDEO_INFO_EMBED, VIDEO_INFO_ANDROID
@@ -81,7 +82,7 @@ public class VideoInfoService extends VideoInfoServiceBase {
         }
 
         if (mSkipAuth) {
-            result.sync(getVideoInfo(VIDEO_INFO_TV, videoId, clickTrackingParams));
+            result.sync(getVideoInfo(AppClient.TV, videoId, clickTrackingParams));
         }
 
         result = retryIfNeeded(result, videoId, clickTrackingParams);
@@ -149,6 +150,9 @@ public class VideoInfoService extends VideoInfoServiceBase {
                 break;
             case WEB_EMBEDDED_PLAYER:
                 result = getVideoInfo(AppClient.WEB_EMBEDDED_PLAYER, videoId, clickTrackingParams);
+                break;
+            case ANDROID_VR:
+                result = getVideoInfo(AppClient.ANDROID_VR, videoId, clickTrackingParams);
                 break;
             case VIDEO_INFO_MWEB:
                 result = getVideoInfo(AppClient.MWEB, videoId, clickTrackingParams);
@@ -319,12 +323,12 @@ public class VideoInfoService extends VideoInfoServiceBase {
 
         VideoInfo result = null;
 
-        if (videoInfo.isUnplayable() && videoInfo.isRent()) {
+        if (videoInfo.isRent()) {
             Log.e(TAG, "Found rent content. Show trailer instead...");
             result = getVideoInfo(AppClient.TV, videoInfo.getTrailerVideoId(), clickTrackingParams);
         } else if (videoInfo.isUnplayable()) {
             result = getFirstPlayable(
-                    () -> getVideoInfo(AppClient.EMBED, videoId, clickTrackingParams), // Restricted (18+) videos
+                    () -> getVideoInfo(AppClient.ANDROID_VR, videoId, clickTrackingParams), // Restricted (18+) videos
                     //() -> getVideoInfoRestricted(videoId, clickTrackingParams, AppClient.MWEB), // Restricted videos (no history)
                     () -> getVideoInfoGeo(AppClient.WEB, videoId, clickTrackingParams), // Video clip blocked in current location
                     () -> {

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/videoinfo/V2/VideoInfoService.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/videoinfo/V2/VideoInfoService.java
@@ -11,7 +11,6 @@ import com.liskovsoft.youtubeapi.app.AppService;
 import com.liskovsoft.youtubeapi.app.PoTokenGate;
 import com.liskovsoft.youtubeapi.common.helpers.AppClient;
 import com.liskovsoft.youtubeapi.common.helpers.RetrofitHelper;
-import com.liskovsoft.youtubeapi.service.YouTubeSignInService;
 import com.liskovsoft.youtubeapi.service.internal.MediaServiceData;
 import com.liskovsoft.youtubeapi.videoinfo.InitialResponse;
 import com.liskovsoft.youtubeapi.videoinfo.VideoInfoServiceBase;

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/videoinfo/V2/VideoInfoService.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/videoinfo/V2/VideoInfoService.java
@@ -36,10 +36,12 @@ public class VideoInfoService extends VideoInfoServiceBase {
     private final static int VIDEO_INFO_ANDROID = 4;
     private final static int VIDEO_INFO_IOS = 5;
     private final static int VIDEO_INFO_EMBED = 6;
+    private final static int WEB_EMBEDDED_PLAYER = 7;
     private final static Integer[] VIDEO_INFO_TYPE_LIST = {
             //VIDEO_INFO_TV, VIDEO_INFO_IOS, VIDEO_INFO_EMBED, VIDEO_INFO_MWEB, VIDEO_INFO_ANDROID, VIDEO_INFO_INITIAL, VIDEO_INFO_WEB
             //VIDEO_INFO_WEB, VIDEO_INFO_MWEB, VIDEO_INFO_INITIAL, VIDEO_INFO_TV, VIDEO_INFO_IOS, VIDEO_INFO_EMBED, VIDEO_INFO_ANDROID
-            VIDEO_INFO_WEB
+//            VIDEO_INFO_WEB,
+            WEB_EMBEDDED_PLAYER,
     };
     private int mVideoInfoType = -1;
     private boolean mSkipAuth;
@@ -133,7 +135,7 @@ public class VideoInfoService extends VideoInfoServiceBase {
             case VIDEO_INFO_INITIAL:
                 result = InitialResponse.getVideoInfo(videoId, mSkipAuthBlock);
                 if (result != null) {
-                    VideoInfo syncInfo = getVideoInfo(AppClient.WEB, videoId, clickTrackingParams);
+                    VideoInfo syncInfo = getVideoInfo(AppClient.WEB_EMBEDDED_PLAYER, videoId, clickTrackingParams);
                     result.sync(syncInfo);
                     break;
                 }
@@ -144,6 +146,9 @@ public class VideoInfoService extends VideoInfoServiceBase {
                 break;
             case VIDEO_INFO_WEB:
                 result = getVideoInfo(AppClient.WEB, videoId, clickTrackingParams);
+                break;
+            case WEB_EMBEDDED_PLAYER:
+                result = getVideoInfo(AppClient.WEB_EMBEDDED_PLAYER, videoId, clickTrackingParams);
                 break;
             case VIDEO_INFO_MWEB:
                 result = getVideoInfo(AppClient.MWEB, videoId, clickTrackingParams);
@@ -294,7 +299,7 @@ public class VideoInfoService extends VideoInfoServiceBase {
 
             if (mCachedTranslationLanguages == null) {
                 mSkipAuthBlock = true;
-                VideoInfo webInfo = getVideoInfo(AppClient.WEB, videoId, clickTrackingParams);
+                VideoInfo webInfo = getVideoInfo(AppClient.WEB_EMBEDDED_PLAYER, videoId, clickTrackingParams);
                 mSkipAuthBlock = false;
                 if (webInfo != null) {
                     mCachedTranslationLanguages = webInfo.getTranslationLanguages();

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/videoinfo/V2/VideoInfoService.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/videoinfo/V2/VideoInfoService.java
@@ -41,8 +41,8 @@ public class VideoInfoService extends VideoInfoServiceBase {
     private final static Integer[] VIDEO_INFO_TYPE_LIST = {
             //VIDEO_INFO_TV, VIDEO_INFO_IOS, VIDEO_INFO_EMBED, VIDEO_INFO_MWEB, VIDEO_INFO_ANDROID, VIDEO_INFO_INITIAL, VIDEO_INFO_WEB
             //VIDEO_INFO_WEB, VIDEO_INFO_MWEB, VIDEO_INFO_INITIAL, VIDEO_INFO_TV, VIDEO_INFO_IOS, VIDEO_INFO_EMBED, VIDEO_INFO_ANDROID
-//            VIDEO_INFO_WEB,
-            WEB_EMBEDDED_PLAYER, VIDEO_INFO_TV, VIDEO_INFO_WEB
+//            VIDEO_INFO_WEB, VIDEO_INFO_TV, VIDEO_INFO_WEB
+            WEB_EMBEDDED_PLAYER,
     };
     private int mVideoInfoType = -1;
     private boolean mSkipAuth;


### PR DESCRIPTION
Time from time WEB client have problems with video loading. Using WEB_EMBEDDED_PLAYER also can theoretically bypass 403 error on some videos. 


![image](https://github.com/user-attachments/assets/bce117bb-31f3-4411-83bd-022cb3341232)
![image](https://github.com/user-attachments/assets/af06c8ce-d1d1-4671-8597-f3d9392da5c9)

Instead of EMBED (TVHTML5_SIMPLY_EMBEDDED_PLAYER), we can use ANDROID_VR client. It resolve problems for videos with 403 error, but limited to 2160p without HDR (and i don't know if it supports Restricted (18+) videos).

![image](https://github.com/user-attachments/assets/d26e01e6-b666-4c2b-922d-78b2f73b7010)
![image](https://github.com/user-attachments/assets/463ece93-681b-4880-90ef-8db751a7cc24)

From: https://github.com/pixkk/VueTube/blob/main/NUXT/plugins/constants.js. 
Another formats: https://github.com/zerodytrash/YouTube-Internal-Clients.

<details>
  <summary>Another formats from YT (without  additional information)</summary>
1. MWEB <br>
2. TVHTML5   <br>
3. TVHTML5_AUDIO   <br>
4. TVHTML5_CAST   <br>
5. TVHTML5_KIDS   <br>
6. TVHTML5_FOR_KIDS   <br>
7. TVHTML5_SIMPLY   <br>
8. TVHTML5_SIMPLY_EMBEDDED_PLAYER   <br>
9. TVHTML5_UNPLUGGED   <br>
10. TVHTML5_VR   <br>
11. TV_UNPLUGGED_CAST   <br>
12. WEB   <br>
13. WEB_CREATOR   <br>
14. WEB_EMBEDDED_PLAYER   <br>
15. WEB_EXPERIMENTS   <br>
16. WEB_GAMING   <br>
17. WEB_HEROES   <br>
18. WEB_KIDS   <br>
19. WEB_LIVE_STREAMING   <br>
20. WEB_MUSIC   <br>
21. WEB_MUSIC_ANALYTICS   <br>
22. WEB_REMIX   <br>
23. WEB_UNPLUGGED   <br>
24. WEB_UNPLUGGED_ONBOARDING   <br>
25. WEB_UNPLUGGED_OPS   <br>
26. WEB_UNPLUGGED_PUBLIC  <br>
  
</details>
