### PR TITLE
fix: WEB_EMBEDDED_PLAYER music video fix.

### DIFF
--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/app/potokennp/PoTokenProviderImpl.kt
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/app/potokennp/PoTokenProviderImpl.kt
@@ -27,11 +27,7 @@ internal object PoTokenProviderImpl : PoTokenProvider {
         }
 
         try {
-            return try {
-                getWebClientPoToken(videoId = videoId, forceRecreate = false)
-            } catch (e: RuntimeException) {
-                getWebClientPoToken(videoId = videoId, forceRecreate = true)
-            }
+            return getWebClientPoToken(videoId = videoId, forceRecreate = false)
         } catch (e: RuntimeException) {
             // RxJava's Single wraps exceptions into RuntimeErrors, so we need to unwrap them here
             when (val cause = e.cause) {

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/app/potokennp/PoTokenProviderImpl.kt
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/app/potokennp/PoTokenProviderImpl.kt
@@ -27,7 +27,11 @@ internal object PoTokenProviderImpl : PoTokenProvider {
         }
 
         try {
-            return getWebClientPoToken(videoId = videoId, forceRecreate = false)
+            return try {
+                getWebClientPoToken(videoId = videoId, forceRecreate = false)
+            } catch (e: RuntimeException) {
+                getWebClientPoToken(videoId = videoId, forceRecreate = true)
+            }
         } catch (e: RuntimeException) {
             // RxJava's Single wraps exceptions into RuntimeErrors, so we need to unwrap them here
             when (val cause = e.cause) {

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/common/helpers/PostDataBuilder.kt
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/common/helpers/PostDataBuilder.kt
@@ -13,6 +13,7 @@ internal class PostDataBuilder(val client: AppClient) {
     private var clickTrackingParams: String? = null
     private var poToken: String? = null
     private var signatureTimestamp: Int? = null
+    private var isWebEmbedded: Boolean? = null
 
     fun setType(type: PostDataType) = apply { this.type = type }
     fun setLanguage(lang: String?) = apply { acceptLanguage = lang }
@@ -24,6 +25,7 @@ internal class PostDataBuilder(val client: AppClient) {
     fun setSignatureTimestamp(timestamp: Int?) = apply { signatureTimestamp = timestamp }
     fun setClickTrackingParams(params: String?) = apply { clickTrackingParams = params }
     fun setVisitorData(visitorData: String?) = apply { this.visitorData = visitorData }
+    fun setAsWebEmbedded() = apply { this.isWebEmbedded = true}
 
     fun build(): String {
         return """
@@ -31,7 +33,8 @@ internal class PostDataBuilder(val client: AppClient) {
                 "context": {
                      ${createClientChunk()},
                      ${createClickTrackingChunk()?.let { "$it," } ?: ""}
-                     ${createUserChunk()}
+                     ${createUserChunk()},
+                     ${createWebEmbeddedChunk()?.let { "$it," } ?: ""}
                 },
                 "racyCheckOk": true,
                 "contentCheckOk": true,
@@ -79,6 +82,15 @@ internal class PostDataBuilder(val client: AppClient) {
             """
                 "clickTracking": {
                     "clickTrackingParams": "$it"
+                }
+            """.trimIndent()
+        }
+    }
+    private fun createWebEmbeddedChunk(): String? {
+        return isWebEmbedded?.let {
+            """
+                "thirdParty": {
+                    "embedUrl": "https://www.youtube.com/embed/$videoId"
                 }
             """.trimIndent()
         }

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/videoinfo/V2/VideoInfoApiHelper.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/videoinfo/V2/VideoInfoApiHelper.java
@@ -74,18 +74,21 @@ public class VideoInfoApiHelper {
         // Otherwise, google suggestions and history won't work (visitor data bug)
         if ((client == AppClient.WEB || client == AppClient.MWEB || client == AppClient.WEB_EMBEDDED_PLAYER) && PoTokenGate.supportsNpPot()) {
             LocaleManager localeManager = LocaleManager.instance();
-            return new PostDataBuilder(client)
+            PostDataBuilder builder = new PostDataBuilder(client)
                     .setType(PostDataType.Player)
                     .setLanguage(localeManager.getLanguage())
                     .setCountry(localeManager.getCountry())
                     .setUtcOffsetMinutes(localeManager.getUtcOffsetMinutes())
                     .setVideoId(videoId)
                     .setClickTrackingParams(clickTrackingParams)
-                    .setClientPlaybackNonce(AppService.instance().getClientPlaybackNonce()) // get it somewhere else?
-                    .setSignatureTimestamp(Helpers.parseInt(AppService.instance().getSignatureTimestamp())) // get it somewhere else?
+                    .setClientPlaybackNonce(AppService.instance().getClientPlaybackNonce())
+                    .setSignatureTimestamp(Helpers.parseInt(AppService.instance().getSignatureTimestamp()))
                     .setPoToken(PoTokenGate.getContentPoToken(videoId))
-                    .setVisitorData(PoTokenGate.getVisitorData())
-                    .build();
+                    .setVisitorData(PoTokenGate.getVisitorData());
+            if (client == AppClient.WEB_EMBEDDED_PLAYER) {
+                builder.setAsWebEmbedded();
+            }
+            return builder.build();
         }
 
         String template = client.getPlayerTemplate();

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/videoinfo/V2/VideoInfoApiHelper.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/videoinfo/V2/VideoInfoApiHelper.java
@@ -74,7 +74,7 @@ public class VideoInfoApiHelper {
         // Otherwise, google suggestions and history won't work (visitor data bug)
         if (isPotSupported(client) && PoTokenGate.supportsNpPot()) {
             LocaleManager localeManager = LocaleManager.instance();
-            QueryBuilder builder = new PostDataBuilder(client)
+            QueryBuilder builder = new QueryBuilder(client)
                     .setType(PostDataType.Player)
                     .setLanguage(localeManager.getLanguage())
                     .setCountry(localeManager.getCountry())

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/videoinfo/V2/VideoInfoService.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/videoinfo/V2/VideoInfoService.java
@@ -80,8 +80,13 @@ public class VideoInfoService extends VideoInfoServiceBase {
             return null;
         }
 
+        // In which cases we need to send second request for getting information about video?
+        // (First request as current mVideoInfoType, second as VIDEO_INFO_TV)
+        // Can we do result sync without sending second request as in
+        // getVideoInfo(int type, String videoId, String clickTrackingParams) function
+        // (VIDEO_INFO_INITIAL switch case)?
         if (mSkipAuth) {
-            result.sync(getVideoInfo(VIDEO_INFO_TV, videoId, clickTrackingParams));
+            result.sync(result);
         }
 
         result = retryIfNeeded(result, videoId, clickTrackingParams);

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/videoinfo/V2/VideoInfoService.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/videoinfo/V2/VideoInfoService.java
@@ -421,7 +421,7 @@ public class VideoInfoService extends VideoInfoServiceBase {
     }
 
     private boolean isMusicRestricted(int videoInfoType) {
-        return videoInfoType == VIDEO_INFO_EMBED || videoInfoType == WEB_EMBEDDED_PLAYER;
+        return videoInfoType == VIDEO_INFO_EMBED;
     }
 
     private static boolean isAuthSupported(int videoInfoType) {


### PR DESCRIPTION
1. QueryBuilder - i added createWebEmbeddedChunk (context.thirdParty params) for WEB_EMBEDDED_PLAYER to unblock some videos. Tested on music videos (for example - https://www.youtube.com/watch?v=vBynw9Isr28, https://www.youtube.com/watch?v=AlYdp8P1s6c). So, if music is working, maybe we can remove W_E_P from isMusicRestricted?

**Before (json response)**
![image](https://github.com/user-attachments/assets/826a9504-7529-42ed-bab0-e828193b88b2)

**After  (json response)**
![image](https://github.com/user-attachments/assets/caced6e7-38bb-4454-a8fb-9a1e9d9ffe26)

2. In which cases we need to send second request for getting information about video (First request as current mVideoInfoType, second as VIDEO_INFO_TV)? Can we do result sync without sending second request as in        getVideoInfo(int type, String videoId, String clickTrackingParams) function (VIDEO_INFO_INITIAL switch case)?
