### PR TITLE
fix: fixing and simplifying regex for NFunction

### DIFF
--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/common/js/JSInterpret.kt
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/common/js/JSInterpret.kt
@@ -22,23 +22,34 @@ internal object JSInterpret {
     fun extractFunctionCode(jsCode: String, funcName: String): Pair<List<String>, String> {
         val escapedFuncName = Pattern.quote(funcName)
         val pattern = Pattern.compile(
-            """(?xs)
-                (?:
-                    function\s+$escapedFuncName|
-                    [{;,]\s*$escapedFuncName\s*=\s*function|
-                    (?:var|const|let)\s+$escapedFuncName\s*=\s*function
-                )\s*
-                \(([^)]*)\)\s*
-                (\{.+\})
+            """(?xm)
+                (?:function\s+$escapedFuncName|
+                [{;,]\s*$escapedFuncName\s*=\s*function|
+                (?:var|const|let)\s+$escapedFuncName\s*=\s*function)
+                \(([^)]*)\)\{([\s\S]*?return.*?\.join\(.*\))
             """.trimIndent()
         )
+//        val pattern = Pattern.compile(
+//
+//            """(?xs)
+//                (?:
+//                    function\s+$escapedFuncName|
+//                    [{;,]\s*$escapedFuncName\s*=\s*function|
+//                    (?:var|const|let)\s+$escapedFuncName\s*=\s*function
+//                )\s*
+//                \(([^)]*)\)\s*
+//                (\{.+\})
+//            """.trimIndent()
+//        )
+
         val matcher = pattern.matcher(jsCode)
         if (!matcher.find()) {
             throw IllegalStateException("Could not find JS function \"$funcName\"")
         }
         val args = matcher.group(1)?.split(",")?.map { it.trim() } ?: emptyList()
         val codeBlock = matcher.group(2) ?: ""
-        val (code, _) = separateAtParen(codeBlock)
+//        val (code, _) = separateAtParen(codeBlock)
+        val code = codeBlock
         return Pair(args, code)
     }
 


### PR DESCRIPTION
I updated regex for better function body cutting. First of all we need to parse only necessary function (without another very big text). It can resolve problem with Nfunction creating and speed up it creation.

**Before:**
![image](https://github.com/user-attachments/assets/6ceb5bc4-fc44-4fe5-a8da-6d35351e3ab6)


**After:**
![image](https://github.com/user-attachments/assets/2c2fa731-e2c5-4e43-907f-d4b93789297a)

