### PR TITLE
Implemented text in the video card to notify of Members first or only

### DIFF
--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/common/models/gen/CommonHelper.kt
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/common/models/gen/CommonHelper.kt
@@ -21,6 +21,7 @@ private const val BADGE_STYLE_DEFAULT = "DEFAULT"
 private const val STATUS_STYLE_MOVIE = "BADGE_STYLE_TYPE_YPC" // This mark sometimes presents on regular videos (e.g. fundraiser mark)
 private const val STATUS_STYLE_QUALITY = "BADGE_STYLE_TYPE_SIMPLE"
 private const val STATUS_STYLE_LIVE = "BADGE_STYLE_TYPE_LIVE_NOW"
+private const val STATUS_STYLE_MEMBERS = "BADGE_STYLE_TYPE_MEMBERS_ONLY" // "Members first" (early access) or "Members only"
 
 ///////////
 
@@ -109,6 +110,9 @@ internal fun VideoItem.getPercentWatched() = thumbnailOverlays?.firstNotNullOfOr
 internal fun VideoItem.getStartTimeSeconds() = navigationEndpoint?.getStartTimeSeconds()
 internal fun VideoItem.getBadgeText() = thumbnailOverlays?.firstNotNullOfOrNull { it?.thumbnailOverlayTimeStatusRenderer?.text?.getText() } ?:
     badges?.firstNotNullOfOrNull { it?.liveBadge?.label?.getText() ?: it?.upcomingEventBadge?.label?.getText() }
+internal fun VideoItem.getMembersBadgeText() = badges?.firstNotNullOfOrNull {
+    it?.metadataBadgeRenderer?.takeIf { it.style == STATUS_STYLE_MEMBERS }?.label
+}
 internal fun VideoItem.getUserName() = shortBylineText?.getText() ?: longBylineText?.getText()
 internal fun VideoItem.getPublishedTimeText() = publishedTimeText?.getText()
 internal fun VideoItem.getViewCount() = shortViewCountText?.getText() ?: viewCountText?.getText() ?: videoInfo?.getText()
@@ -190,6 +194,10 @@ internal fun TileItem.getSubTitle() = metadata?.tileMetadataRenderer?.lines
 internal fun TileItem.getBadgeText() = header?.tileHeaderRenderer?.thumbnailOverlays
     ?.firstNotNullOfOrNull { it?.thumbnailOverlayTimeStatusRenderer?.text?.getText() }
     ?: header?.trackTileHeaderRenderer?.duration?.getText()
+internal fun TileItem.getMembersBadgeText() = metadata?.tileMetadataRenderer?.lines
+    ?.firstNotNullOfOrNull { line -> line?.lineRenderer?.items?.firstNotNullOfOrNull { item ->
+        item?.lineItemRenderer?.badge?.metadataBadgeRenderer?.takeIf { it.style == STATUS_STYLE_MEMBERS }?.label
+    } }
 internal fun TileItem.getVideoId() = onSelectCommand?.getVideoId()
 internal fun TileItem.getPlaylistId() = onSelectCommand?.getPlaylistId() ?: getMenu()?.getPlaylistId()
 internal fun TileItem.getPlaylistIndex() = 0
@@ -318,6 +326,7 @@ internal fun ItemWrapper.getMovingThumbnails() = getVideoItem()?.getMovingThumbn
 internal fun ItemWrapper.getLengthText() = getVideoItem()?.getLengthText() ?: getMusicItem()?.getLengthText() ?: getTileItem()?.getBadgeText()
 internal fun ItemWrapper.getBadgeText() = getVideoItem()?.getBadgeText() ?: getMusicItem()?.getBadgeText() ?: getTileItem()?.getBadgeText()
 ?: getPlaylistItem()?.getBadgeText() ?: getChannelItem()?.getBadgeText() ?: getLockupItem()?.getBadgeText()
+internal fun ItemWrapper.getMembersBadgeText() = getVideoItem()?.getMembersBadgeText() ?: getTileItem()?.getMembersBadgeText()
 internal fun ItemWrapper.getPercentWatched() = getVideoItem()?.getPercentWatched() ?: getTileItem()?.getPercentWatched() ?: getLockupItem()?.getPercentWatched()
 internal fun ItemWrapper.getStartTimeSeconds() = getVideoItem()?.getStartTimeSeconds() ?: getTileItem()?.getStartTimeSeconds()
 internal fun ItemWrapper.getUserName() = getVideoItem()?.getUserName() ?: getMusicItem()?.getUserName() ?: getTileItem()?.getUserName()

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/common/models/impl/mediaitem/MediaItemImpl.kt
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/common/models/impl/mediaitem/MediaItemImpl.kt
@@ -1,5 +1,8 @@
 package com.liskovsoft.youtubeapi.common.models.impl.mediaitem
 
+import android.text.SpannableString
+import android.text.Spanned
+import android.text.style.ForegroundColorSpan
 import com.liskovsoft.sharedutils.helpers.Helpers
 import com.liskovsoft.youtubeapi.browse.v2.gen.*
 import com.liskovsoft.youtubeapi.common.models.gen.*
@@ -7,17 +10,27 @@ import com.liskovsoft.googlecommon.common.helpers.YouTubeHelper
 import com.liskovsoft.youtubeapi.next.v2.gen.*
 import com.liskovsoft.youtubeapi.notifications.gen.*
 
+private const val MEMBERS_BADGE_COLOR = 0xFF2BA640.toInt() // YouTube sponsor green
+
+/** Colors the members-first / members-only label so it stands out on the card's subtitle line. */
+private fun colorizeMembers(label: String): CharSequence =
+    SpannableString(label).apply {
+        setSpan(ForegroundColorSpan(MEMBERS_BADGE_COLOR), 0, length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+    }
+
 internal class WrapperMediaItem(private val itemWrapper: ItemWrapper): BaseMediaItem() {
     override val typeItem by lazy { itemWrapper.getType() }
     override val videoIdItem by lazy { itemWrapper.getVideoId() }
     override val titleItem by lazy { itemWrapper.getTitle() }
     override val secondTitleItem by lazy {
+        // Appended (in green) to the end of the subtitle line so members-first/only cards are recognizable
+        val membersLabel = itemWrapper.getMembersBadgeText()?.let { colorizeMembers(it) }
         val videoInfo = arrayOf(userName, viewCountText, publishedTime, upcomingEventText)
         val hasVideoInfo = !Helpers.allNulls(*videoInfo)
         if (hasVideoInfo) {
-            YouTubeHelper.createInfo(*videoInfo)
+            YouTubeHelper.createInfo(*videoInfo, membersLabel)
         } else {
-            YouTubeHelper.createInfo(subTitle)
+            YouTubeHelper.createInfo(subTitle, membersLabel)
         }
     }
     override val subTitle by lazy { itemWrapper.getSubTitle() } // quality tag (e.g. 4K, LIVE) or full second title


### PR DESCRIPTION
I have implemented text in a video's card to indicate `Members first` or `Members only`. It is passing through the label text to know `first` vs `only`.

 I used the green color to match the regular `YouTube` app.

I kept running into [SmartTube #5831](https://github.com/yuliskov/SmartTube/issues/5831). I wondered why I couldn't open the video and got taken to the channel.

Regular `YouTube` app and `Members first`:
<img width="1344" height="280" alt="image" src="https://github.com/user-attachments/assets/98053a96-24a7-42ce-b08f-8c10fda31ead" />

Example of `Members only`:
<img width="3084" height="4096" alt="signal-2026-06-15-204518_002" src="https://github.com/user-attachments/assets/bb235a0b-a311-4747-a6bd-13bb61fe6099" />

Example of `Members first`:
<img width="3084" height="4096" alt="signal-2026-06-15-204518_003" src="https://github.com/user-attachments/assets/87f270f8-15b5-4d1b-94fb-71c46c75f3d9" />
