### PR TITLE
Fix tight retry-storm in LoungeService reconnect loop

### DIFF
--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/lounge/LoungeService.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/lounge/LoungeService.java
@@ -117,7 +117,18 @@ public class LoungeService {
                 e.printStackTrace();
                 break;
             } catch (Exception e) {
+                // NOTE: without a backoff delay here, a persistent failure (e.g. UnknownHostException
+                // right after the TV wakes from sleep, before WiFi/DNS is actually back up) turns this
+                // into a tight busy-loop retrying every few milliseconds, hammering CPU/DNS and never
+                // giving the network a chance to recover in between attempts. Sleeping between retries
+                // gives WiFi/DNS time to come back up, same as the normal-path delay above.
                 Log.e(TAG, e.getMessage());
+                try {
+                    Thread.sleep(2_000);
+                } catch (InterruptedException interrupted) {
+                    Log.e(TAG, "Oops. Stopping. Listening thread interrupted.");
+                    break;
+                }
                 // Continue to listen whichever is happening.
             }
         }


### PR DESCRIPTION
The generic catch(Exception) branch in startListening() had no backoff delay, unlike the normal-path Thread.sleep(3000) after a clean disconnect. When startListeningInt() throws a persistent error (e.g. UnknownHostException right after the TV's WiFi wakes from sleep, before DNS is actually reachable again), the loop retried in a tight busy-loop every ~10ms, hammering CPU/DNS instead of giving the network a chance to recover, and preventing the cast session from ever successfully (re)binding.

Part of the SmartTube wake-on-cast-while-asleep fix; see WAKE_ON_CAST_FIX.md in the SmartTube repo for the full diagnosis.