### PR TITLE
Fix SABR format metadata and selection

### DIFF
--- a/mediaserviceinterfaces/src/main/java/com/liskovsoft/mediaserviceinterfaces/data/MediaFormat.java
+++ b/mediaserviceinterfaces/src/main/java/com/liskovsoft/mediaserviceinterfaces/data/MediaFormat.java
@@ -18,6 +18,7 @@ public interface MediaFormat extends Comparable<MediaFormat> {
     String getBitrate();
     String getProjectionType();
     String getXtags();
+    String getAudioTrackId();
     int getWidth();
     int getHeight();
     String getIndex();

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/innertube/impl/MediaFormatImpl.kt
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/innertube/impl/MediaFormatImpl.kt
@@ -26,6 +26,8 @@ internal data class MediaFormatImpl(private val streamingFormat: StreamingFormat
     private val _clen by lazy { streamingFormat.contentLength }
     private val _bitrate by lazy { streamingFormat.bitrate?.takeIf { it != 0 }?.toString() ?: "" }
     private val _projectionType by lazy { streamingFormat.projectionType }
+    private val _xtags by lazy { streamingFormat.xtags }
+    private val _audioTrackId by lazy { streamingFormat.audioTrack?.id }
     private val _width by lazy { streamingFormat.width ?: -1 }
     private val _height by lazy { streamingFormat.height ?: -1 }
     private val _initRange by lazy { streamingFormat.getInitRange() }
@@ -58,7 +60,9 @@ internal data class MediaFormatImpl(private val streamingFormat: StreamingFormat
 
     override fun getProjectionType() = _projectionType
 
-    override fun getXtags(): String? = null
+    override fun getXtags() = _xtags
+
+    override fun getAudioTrackId() = _audioTrackId
 
     override fun getWidth() = _width
 

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/innertube/impl/MediaItemFormatInfoImpl.kt
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/innertube/impl/MediaItemFormatInfoImpl.kt
@@ -166,9 +166,15 @@ internal data class MediaItemFormatInfoImpl(private val playerResult: PlayerResu
 
     override fun containsMedia() = containsDashUrl() || containsHlsUrl() || containsAdaptiveVideoFormats() || containsUrlFormats()
 
-    override fun containsSabrFormats() = containsAdaptiveVideoFormats() && getAdaptiveFormats()?.firstOrNull()?.getFormatType() == MediaFormat.FORMAT_TYPE_SABR
+    // A player response may contain legacy adaptive URLs alongside its SABR endpoint.
+    // Prefer the endpoint when the response includes all data needed to use it.
+    override fun containsSabrFormats() = containsAdaptiveVideoFormats()
+            && getServerAbrStreamingUrl() != null
+            && getVideoPlaybackUstreamerConfig() != null
 
-    override fun containsDashFormats() = containsAdaptiveVideoFormats() && getAdaptiveFormats()?.firstOrNull()?.getFormatType() == MediaFormat.FORMAT_TYPE_DASH
+    override fun containsDashFormats() = containsAdaptiveVideoFormats()
+            && !containsSabrFormats()
+            && getAdaptiveFormats()?.firstOrNull()?.getFormatType() == MediaFormat.FORMAT_TYPE_DASH
 
     private fun containsAdaptiveVideoFormats() = _containsAdaptiveVideoFormats
 

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/innertube/models/PlayerResult.kt
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/innertube/models/PlayerResult.kt
@@ -114,6 +114,7 @@ internal data class StreamingFormat(
     val fps: Int?,
     val qualityLabel: String?,
     val projectionType: String?,
+    val xtags: String?,
     val averageBitrate: Int?,
     val approxDurationMs: String?,
     val targetDurationSec: Int?,
@@ -121,6 +122,7 @@ internal data class StreamingFormat(
     val qualityOrdinal: String?,
     // audio
     val highReplication: Boolean?,
+    val audioTrack: AudioTrack?,
     val audioSampleRate: String?,
     val audioChannels: Int?,
     val loudnessDb: Float?,
@@ -147,6 +149,13 @@ internal data class StreamingFormat(
         val end: String?
     )
 }
+
+internal data class AudioTrack(
+    val displayName: String?,
+    val id: String?,
+    val audioIsDefault: Boolean?,
+    val isAutoDubbed: Boolean?
+)
 
 internal data class CaptionTrack(
     val baseUrl: String?,

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/service/data/YouTubeMediaFormat.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/service/data/YouTubeMediaFormat.java
@@ -21,6 +21,7 @@ public class YouTubeMediaFormat implements MediaFormat {
     private String mBitrate;
     private String mProjectionType;
     private String mXtags;
+    private String mAudioTrackId;
     private int mWidth;
     private int mHeight;
     private String mInit;
@@ -90,6 +91,8 @@ public class YouTubeMediaFormat implements MediaFormat {
         mediaFormat.mSegmentUrlList = format.getSegmentUrlList();
         mediaFormat.mGlobalSegmentList = format.getGlobalSegmentList();
         mediaFormat.mLanguage = format.getLanguage();
+        mediaFormat.mXtags = format.getXtags();
+        mediaFormat.mAudioTrackId = format.getAudioTrackId();
         mediaFormat.mTargetDurationSec = format.getTargetDurationSec();
         mediaFormat.mLmt = format.getLastModified();
         mediaFormat.mQualityLabel = format.getQualityLabel();
@@ -157,6 +160,11 @@ public class YouTubeMediaFormat implements MediaFormat {
     @Override
     public String getXtags() {
         return mXtags;
+    }
+
+    @Override
+    public String getAudioTrackId() {
+        return mAudioTrackId;
     }
 
     @Override

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/service/data/YouTubeMediaItemFormatInfo.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/service/data/YouTubeMediaItemFormatInfo.java
@@ -228,12 +228,16 @@ public class YouTubeMediaItemFormatInfo implements MediaItemFormatInfo {
 
     @Override
     public boolean containsSabrFormats() {
-        return mContainsAdaptiveVideoFormats && mAdaptiveFormats.get(0).getFormatType() == MediaFormat.FORMAT_TYPE_SABR;
+        // A player response may contain legacy adaptive URLs alongside its SABR endpoint.
+        // Prefer the endpoint when the response includes all data needed to use it.
+        return mContainsAdaptiveVideoFormats && mServerAbrStreamingUrl != null
+                && mVideoPlaybackUstreamerConfig != null;
     }
 
     @Override
     public boolean containsDashFormats() {
-        return mContainsAdaptiveVideoFormats && mAdaptiveFormats.get(0).getFormatType() == MediaFormat.FORMAT_TYPE_DASH;
+        return mContainsAdaptiveVideoFormats && !containsSabrFormats()
+                && mAdaptiveFormats.get(0).getFormatType() == MediaFormat.FORMAT_TYPE_DASH;
     }
     
     private boolean containsAdaptiveVideoFormats() {

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/videoinfo/models/formats/VideoFormat.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/videoinfo/models/formats/VideoFormat.java
@@ -47,7 +47,10 @@ public class VideoFormat {
     private int mAverageBitrate;
     @JsonPath("$.projectionType")
     private String mProjectionType;
+    @JsonPath("$.xtags")
     private String mXtags;
+    @JsonPath("$.audioTrack.id")
+    private String mAudioTrackId;
     @JsonPath("$.width")
     private int mWidth = -1;
     @JsonPath("$.height")
@@ -143,6 +146,10 @@ public class VideoFormat {
 
     public void setXtags(String xtags) {
         mXtags = xtags;
+    }
+
+    public String getAudioTrackId() {
+        return mAudioTrackId;
     }
 
     public int getWidth() {

--- a/youtubeapi/src/test/java/com/liskovsoft/youtubeapi/innertube/impl/MediaItemFormatInfoImplTest.kt
+++ b/youtubeapi/src/test/java/com/liskovsoft/youtubeapi/innertube/impl/MediaItemFormatInfoImplTest.kt
@@ -29,11 +29,13 @@ class MediaItemFormatInfoImplTest {
     @Test
     fun responseWithoutSabrEndpointRetainsDashFallback() {
         val response = parsePlayerResponse("player/web/2025.11.10_player_regular.json")
-        val dashFormat = response.streamingData?.adaptiveFormats?.first()?.copy(
-            url = "https://example.com/videoplayback",
-            cipher = null,
-            signatureCipher = null
-        )
+        val dashFormat = response.streamingData?.adaptiveFormats
+            ?.first { it.mimeType?.startsWith("video/") == true }
+            ?.copy(
+                url = "https://example.com/videoplayback",
+                cipher = null,
+                signatureCipher = null
+            )
         val withoutSabrEndpoint = response.copy(
             streamingData = response.streamingData?.copy(
                 adaptiveFormats = listOfNotNull(dashFormat),
@@ -41,6 +43,34 @@ class MediaItemFormatInfoImplTest {
             )
         )
         val formatInfo = MediaItemFormatInfoImpl(withoutSabrEndpoint)
+
+        assertFalse(formatInfo.containsSabrFormats())
+        assertTrue(formatInfo.containsDashFormats())
+        assertEquals(MediaFormat.FORMAT_TYPE_DASH, formatInfo.getAdaptiveFormats()?.first()?.getFormatType())
+    }
+
+    @Test
+    fun responseWithoutUstreamerConfigRetainsDashFallback() {
+        val response = parsePlayerResponse("player/web/2025.11.10_player_regular.json")
+        val dashFormat = response.streamingData?.adaptiveFormats
+            ?.first { it.mimeType?.startsWith("video/") == true }
+            ?.copy(
+                url = "https://example.com/videoplayback",
+                cipher = null,
+                signatureCipher = null
+            )
+        val withoutUstreamerConfig = response.copy(
+            streamingData = response.streamingData?.copy(
+                adaptiveFormats = listOfNotNull(dashFormat),
+                serverAbrStreamingUrl = "https://example.com/sabr"
+            ),
+            playerConfig = response.playerConfig?.copy(
+                mediaCommonConfig = response.playerConfig.mediaCommonConfig?.copy(
+                    mediaUstreamerRequestConfig = null
+                )
+            )
+        )
+        val formatInfo = MediaItemFormatInfoImpl(withoutUstreamerConfig)
 
         assertFalse(formatInfo.containsSabrFormats())
         assertTrue(formatInfo.containsDashFormats())

--- a/youtubeapi/src/test/java/com/liskovsoft/youtubeapi/innertube/impl/MediaItemFormatInfoImplTest.kt
+++ b/youtubeapi/src/test/java/com/liskovsoft/youtubeapi/innertube/impl/MediaItemFormatInfoImplTest.kt
@@ -1,0 +1,52 @@
+package com.liskovsoft.youtubeapi.innertube.impl
+
+import com.google.gson.Gson
+import com.liskovsoft.mediaserviceinterfaces.data.MediaFormat
+import com.liskovsoft.sharedutils.TestHelpers
+import com.liskovsoft.youtubeapi.innertube.models.PlayerResult
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MediaItemFormatInfoImplTest {
+    @Test
+    fun sabrResponsePreservesFormatMetadataAndPrefersSabr() {
+        val formatInfo = MediaItemFormatInfoImpl(
+            parsePlayerResponse("player/web/2025.11.10_player_sabr_only.json")
+        )
+        val audioFormat = formatInfo.getAdaptiveFormats()
+            ?.firstOrNull { it.getAudioTrackId() != null }
+
+        assertTrue(formatInfo.containsSabrFormats())
+        assertFalse(formatInfo.containsDashFormats())
+        assertNotNull(audioFormat)
+        assertNotNull(audioFormat?.getXtags())
+        assertNotNull(audioFormat?.getAudioTrackId())
+    }
+
+    @Test
+    fun responseWithoutSabrEndpointRetainsDashFallback() {
+        val response = parsePlayerResponse("player/web/2025.11.10_player_regular.json")
+        val dashFormat = response.streamingData?.adaptiveFormats?.first()?.copy(
+            url = "https://example.com/videoplayback",
+            cipher = null,
+            signatureCipher = null
+        )
+        val withoutSabrEndpoint = response.copy(
+            streamingData = response.streamingData?.copy(
+                adaptiveFormats = listOfNotNull(dashFormat),
+                serverAbrStreamingUrl = null
+            )
+        )
+        val formatInfo = MediaItemFormatInfoImpl(withoutSabrEndpoint)
+
+        assertFalse(formatInfo.containsSabrFormats())
+        assertTrue(formatInfo.containsDashFormats())
+        assertEquals(MediaFormat.FORMAT_TYPE_DASH, formatInfo.getAdaptiveFormats()?.first()?.getFormatType())
+    }
+
+    private fun parsePlayerResponse(path: String) =
+        Gson().fromJson(TestHelpers.readResource(path), PlayerResult::class.java)
+}


### PR DESCRIPTION
This is the MediaServiceCore part of the SABR playback work from yuliskov/SmartTube#6030.

Some player responses contain ordinary adaptive URLs as well as `serverAbrStreamingUrl`. The current first-format check classifies those responses as DASH, so SmartTube never uses the complete SABR endpoint even when the accompanying ustreamer configuration is present.

This change:

- selects SABR when both the streaming URL and ustreamer configuration are available, while keeping DASH as the fallback
- parses and preserves `xtags` and `audioTrack.id` through both format-model paths
- exposes the audio track ID through `MediaFormat` so the SmartTube SABR request can identify multi-audio tracks correctly
- adds regression coverage using the existing regular and SABR-only player-response fixtures

I tested the unit test through the current SmartTube Gradle build with:

```
./gradlew :youtubeapi:testStbetaDebugUnitTest --tests com.liskovsoft.youtubeapi.innertube.impl.MediaItemFormatInfoImplTest
```

The corresponding SmartTube changes are being kept separate until this dependency is merged.