### PR TITLE
Fix infinite loading spinner on members only content

### DIFF
--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/videoinfo/V2/VideoInfoService.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/videoinfo/V2/VideoInfoService.java
@@ -51,7 +51,6 @@ public class VideoInfoService extends VideoInfoServiceBase {
     private AppClient mActualInfoType = null;
     @Nullable
     private AppClient mNextInfoType = null;
-    private boolean mAuthBlock;
     private List<TranslationLanguage> mCachedTranslationLanguages;
     private boolean mIsUnplayable;
 
@@ -77,9 +76,7 @@ public class VideoInfoService extends VideoInfoServiceBase {
 
         AppService.instance().resetClientPlaybackNonce(); // unique value per each video info
 
-        mAuthBlock = true;
-
-        VideoInfo result = firstPlayable(videoId, clickTrackingParams);
+        VideoInfo result = firstPlayable(videoId, clickTrackingParams, true);
 
         if (result == null) {
             Log.e(TAG, "Can't get video info. videoId: %s", videoId);
@@ -116,29 +113,35 @@ public class VideoInfoService extends VideoInfoServiceBase {
             return null;
         }
 
-        mAuthBlock = true;
-
         // Only the tv client supports auth features
-        return getVideoInfo(AppClient.TV, videoId, clickTrackingParams);
+        return getVideoInfo(AppClient.TV, videoId, clickTrackingParams, true);
     }
 
-    private VideoInfo firstPlayable(String videoId, String clickTrackingParams) {
-        VideoInfo result = firstInfoWith(videoId, clickTrackingParams, info -> !info.isUnplayable());
+    private VideoInfo firstPlayable(String videoId, String clickTrackingParams, boolean auth) {
+        VideoInfo result = firstInfoWith(videoId, clickTrackingParams, info -> !info.isUnplayable(), auth);
 
-        return result != null ? result : firstInfoWith(videoId, clickTrackingParams, info -> info.getRegularFormats() != null);
+        if (result == null) {
+            result = firstInfoWith(videoId, clickTrackingParams, info -> info.getRegularFormats() != null, auth);
+        }
+
+        // No client can play it (e.g. members only content or the video is removed).
+        // Return the unplayable response instead of null. Otherwise the caller gets an empty
+        // result and reloads the video endlessly (infinite loading spinner) instead of
+        // showing the real playability reason to the user.
+        return result != null ? result : firstInfoWith(videoId, clickTrackingParams, info -> true, auth);
     }
 
     private interface InfoTester {
         boolean test(VideoInfo info);
     }
 
-    private VideoInfo firstInfoWith(String videoId, String clickTrackingParams, InfoTester infoTester) {
+    private VideoInfo firstInfoWith(String videoId, String clickTrackingParams, InfoTester infoTester, boolean auth) {
         //final AppClient beginType = getDefaultClient();
         final AppClient beginType = mNextInfoType != null ? mNextInfoType : VIDEO_INFO_TYPE_LIST[0];
         AppClient nextType = beginType;
 
         do {
-            VideoInfo result = getVideoInfoWithRentFix(nextType, videoId, clickTrackingParams);
+            VideoInfo result = getVideoInfoWithRentFix(nextType, videoId, clickTrackingParams, auth);
 
             if (result != null && infoTester.test(result)) {
                 return result;
@@ -189,25 +192,25 @@ public class VideoInfoService extends VideoInfoServiceBase {
         mNextInfoType = Helpers.getNextValue(VIDEO_INFO_TYPE_LIST, mActualInfoType);
     }
 
-    private VideoInfo getVideoInfoWithRentFix(AppClient client, String videoId, String clickTrackingParams) {
-        VideoInfo result = getVideoInfo(client, videoId, clickTrackingParams);
+    private VideoInfo getVideoInfoWithRentFix(AppClient client, String videoId, String clickTrackingParams, boolean auth) {
+        VideoInfo result = getVideoInfo(client, videoId, clickTrackingParams, auth);
 
         if (result != null && result.isRent()) {
             Log.e(TAG, "Found rent content. Show trailer instead...");
-            result = getVideoInfo(client, result.getTrailerVideoId(), clickTrackingParams);
+            result = getVideoInfo(client, result.getTrailerVideoId(), clickTrackingParams, auth);
         }
 
         return result;
     }
 
-    private VideoInfo getVideoInfo(AppClient client, String videoId, String clickTrackingParams) {
+    private VideoInfo getVideoInfo(AppClient client, String videoId, String clickTrackingParams, boolean auth) {
         VideoInfo result;
 
         if (client == AppClient.INITIAL) {
-            result = InitialResponseService.getVideoInfo(videoId, mAuthBlock);
+            result = InitialResponseService.getVideoInfo(videoId, auth);
         } else {
             String videoInfoQuery = VideoInfoApiHelper.getVideoInfoQuery(client, videoId, clickTrackingParams);
-            result = getVideoInfo(client, videoInfoQuery);
+            result = getVideoInfoQuery(client, videoInfoQuery, auth);
         }
 
         if (result != null) {
@@ -217,8 +220,8 @@ public class VideoInfoService extends VideoInfoServiceBase {
         return result;
     }
 
-    private VideoInfo getVideoInfo(AppClient client, String videoInfoQuery) {
-        boolean auth = client.isAuthSupported() && mAuthBlock;
+    private VideoInfo getVideoInfoQuery(AppClient client, String videoInfoQuery, boolean authBlock) {
+        boolean auth = client.isAuthSupported() && authBlock;
 
         if (client.isReelClient()) {
             Call<VideoInfoReel> wrapper = mVideoInfoApi.getVideoInfoReel(videoInfoQuery, mAppService.getVisitorData(),
@@ -255,16 +258,16 @@ public class VideoInfoService extends VideoInfoServiceBase {
         return videoInfo.getVideoInfo();
     }
 
-    private VideoInfoHls getVideoInfoIOSHls(String videoId, String clickTrackingParams) {
+    private VideoInfoHls getVideoInfoIOSHls(String videoId, String clickTrackingParams, boolean auth) {
         String videoInfoQuery = VideoInfoApiHelper.getVideoInfoQuery(IOS_CLIENT, videoId, clickTrackingParams);
-        return getVideoInfoHls(IOS_CLIENT, videoInfoQuery);
+        return getVideoInfoHls(IOS_CLIENT, videoInfoQuery, auth);
     }
 
-    private VideoInfoHls getVideoInfoHls(AppClient client, String videoInfoQuery) {
+    private VideoInfoHls getVideoInfoHls(AppClient client, String videoInfoQuery, boolean authBlock) {
         Call<VideoInfoHls> wrapper = mVideoInfoApi.getVideoInfoHls(videoInfoQuery, mAppService.getVisitorData(),
                 client.getUserAgent(), client.getInnerTubeName(), client.getClientVersion());
 
-        return RetrofitHelper.get(wrapper, client.isAuthSupported() && mAuthBlock);
+        return RetrofitHelper.get(wrapper, client.isAuthSupported() && authBlock);
     }
 
     private void applyFixesIfNeeded(VideoInfo result, String videoId, String clickTrackingParams) {
@@ -274,8 +277,7 @@ public class VideoInfoService extends VideoInfoServiceBase {
 
         if (shouldObtainExtendedFormats(result) || result.isStoryboardBroken()) {
             Log.d(TAG, "Enable high bitrate formats...");
-            mAuthBlock = false;
-            VideoInfoHls videoInfoHls = getVideoInfoIOSHls(videoId, clickTrackingParams);
+            VideoInfoHls videoInfoHls = getVideoInfoIOSHls(videoId, clickTrackingParams, false);
             if (videoInfoHls != null && shouldObtainExtendedFormats(result)) {
                 result.setHlsManifestUrl(videoInfoHls.getHlsManifestUrl());
             }
@@ -289,10 +291,9 @@ public class VideoInfoService extends VideoInfoServiceBase {
             Log.d(TAG, "Enable full list of auto generated subtitles...");
 
             if (mCachedTranslationLanguages == null || mCachedTranslationLanguages.size() < 100) {
-                mAuthBlock = false;
                 VideoInfo webInfo = null;
                 try {
-                    webInfo = getVideoInfo(AppClient.WEB, videoId, clickTrackingParams);
+                    webInfo = getVideoInfo(AppClient.WEB, videoId, clickTrackingParams, false);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }

--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/videoinfo/models/VideoInfo.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/videoinfo/models/VideoInfo.java
@@ -433,6 +433,13 @@ public class VideoInfo {
             return false;
         }
 
+        // The stream is still playable through the manifest even when every format is SABR only.
+        // Without this check such a stream is reported as unplayable and the player never gets
+        // a chance to try the dash/hls manifest it already has.
+        if (getDashManifestUrl() != null || getHlsManifestUrl() != null) {
+            return false;
+        }
+
         boolean allBroken = true;
 
         for (AdaptiveVideoFormat format : mAdaptiveFormats) {


### PR DESCRIPTION
## Problem

Clicking a members only video on Android TV produces an endless loading spinner. Nothing is ever shown to the user and playback never starts.

The loop is:

1. `VideoInfoService.firstPlayable()` walks the client list looking for a playable response, then walks it again looking for one with regular formats. If neither pass matches it returns `null`, **discarding the response that carried the real `playabilityStatus` reason**.
2. `YouTubeMediaItemService.getFormatInfo()` turns that into a `null` `MediaItemFormatInfo`.
3. `RxHelper.fromNullable` emits `IllegalStateException("fromNullable result is null")`.
4. In SmartTube, `ErrorFixerController.runFormatErrorAction()` suppresses the toast for exactly that message and calls `reloadVideo()` unconditionally.
5. The reload re-fires `onNewVideo()` with the same item a second later, and we are back at step 1.

`VideoLoaderController.processFormatInfo()` already handles this properly - it shows the playability reason, hides the spinner, loads suggestions and moves on. That branch is simply never reached, because step 1 nulls the response out.

## Changes

**`VideoInfoService`: return the unplayable response instead of `null`.** When no client can play the video, fall back to the first non-null response so the reason ("Join this channel to get access to members-only content", or whatever it is) reaches the player. Costs at most one extra request, and only in the total-failure case.

**`VideoInfoService`: make the auth flag per call.** `mAuthBlock` is set `true` at the top of `getVideoInfo(videoId, ...)` but set `false` inside `applyFixesIfNeeded()` and never restored. `applyFixesIfNeeded()` runs on most normal videos (the `needMoreSubtitles` branch fires whenever a video has subtitles). Because the service is a singleton and format info is also fetched concurrently - `preloadNextVideoIfNeeded()` and the history update both call `getFormatInfo` on background threads - a background fetch can clear the flag while another lookup is still iterating clients, sending the `TV` / `TV_DOWNGRADED` requests anonymously. That is invisible for public videos and fatal for auth gated ones. The flag is now threaded through as a parameter and the field is gone.

**`VideoInfo`: don't mark manifest-backed live streams unplayable.** `isAdaptiveFormatsBroken()` is ORed into `isUnplayable()` and returns `true` for a live stream whose adaptive formats are all SABR only (no url, no cipher). A members only livestream can therefore be rejected by every client with `playabilityStatus: OK`, even when the response carries a usable dash or hls manifest url that `processFormatInfo` would have played. The SABR check is kept but skipped when a manifest url is present.

## Testing

**Not tested on a device** - I don't have a build environment set up for this, which is why this is a draft. Reviewed by reading the call graph only. The first change is the one that directly kills the spinner; the other two are the two candidate reasons an authenticated member sees an unplayable response in the first place, and I could not determine from source alone which one applies.

Companion app-side change: yuliskov/SmartTube#6122

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtUccbY1niFoszZPv6jJqp