### PR TITLE
fix(videoinfo): add TV_DOWNGRADED as authenticated fallback for member-only and restricted streams

### DIFF
--- a/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/videoinfo/V2/VideoInfoService.java
+++ b/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/videoinfo/V2/VideoInfoService.java
@@ -30,23 +30,17 @@ public class VideoInfoService extends VideoInfoServiceBase {
     private static final AppClient WEB_CLIENT = AppClient.WEB_EMBED;
     private static VideoInfoService sInstance;
     private final VideoInfoApi mVideoInfoApi;
-    // TODO: tv clients are fully broken because of '-tcl' player
+    // TV clients used as authenticated fallback for member-only/restricted videos
     private final static AppClient[] VIDEO_INFO_TYPE_LIST = {
             AppClient.WEB_EMBED, // Restricted (18+) videos
             AppClient.VISIONOS, // no url formats
-            //AppClient.TV_DOWNGRADED, // probably unplayable (weird potoken format?)
-            //AppClient.TV, // Supports auth. Fixes "please sign in" bug! (the best for Premium users)
-            //AppClient.ANDROID_REEL, // doesn't require pot and cipher (hangs on all engines)
             AppClient.WEB, // Fix video clip blocked in current location
             AppClient.WEB_SAFARI,
             AppClient.IOS,
             AppClient.GEO, // Fix video clip blocked in current location
             AppClient.MWEB, // single audio language
-            //AppClient.TV_LEGACY,
-            //AppClient.TV_EMBED, // single audio language
             AppClient.ANDROID_VR, // doesn't require pot and cipher (often hangs?)
-            //AppClient.TV_SIMPLY, // hangs?
-            //AppClient.ANDROID_SDK_LESS, // doesn't require pot (hangs on Cronet!)
+            AppClient.TV_DOWNGRADED, // Authenticated fallback for member-only, paid, and restricted streams
     };
     @Nullable
     private AppClient mActualInfoType = null;


### PR DESCRIPTION
### Summary of Changes

In \VideoInfoService.java\, add \AppClient.TV_DOWNGRADED\ as the final authenticated fallback client at the end of \VIDEO_INFO_TYPE_LIST\.

### Problem Statement & Context
- Fast clients (\WEB_EMBED\, \VISIONOS\) work well for general public videos, but fail or reject streams when accessing member-only content, paid streams, or account-restricted videos requiring user session credentials.
- When unauthenticated and web clients in \VIDEO_INFO_TYPE_LIST\ are exhausted, playback terminates with an error rather than attempting an authenticated TV client fallback.

### Solution
- By appending \AppClient.TV_DOWNGRADED\ at the end of \VIDEO_INFO_TYPE_LIST\:
  - General videos continue to prioritize fast unauthenticated clients first (\WEB_EMBED\, \VISIONOS\, \WEB\, \WEB_SAFARI\, \IOS\, \GEO\, \MWEB\, \ANDROID_VR\).
  - If those clients fail (e.g., HTTP 403 or signature rejection on member/paid content), \VideoInfoService\ falls back to \TV_DOWNGRADED\, enabling playback using the user's active authenticated session.

### Related
- SmartTube PR: https://github.com/yuliskov/SmartTube/pull/6160